### PR TITLE
feat: Living Ecosystem & Genetics for FreeExploreEndless

### DIFF
--- a/Assets/ProceduralTerrain/CreateEnv/EnvironmentBounds.cs
+++ b/Assets/ProceduralTerrain/CreateEnv/EnvironmentBounds.cs
@@ -83,6 +83,10 @@ namespace CreateEnv
             if (p.simple == null) p.simple = new SimpleEnvironmentSettings();
             p.simple.Clamp();
 
+            // Living Ecosystem layer — same rule: never trust the incoming object.
+            if (p.ecosystem == null) p.ecosystem = new Ecosystem.EcosystemSettings();
+            p.ecosystem.Clamp();
+
             // Group 1
             p.noiseScale  = NoiseScale.Clamp(p.noiseScale);
             p.octaves     = Octaves.ClampInt(p.octaves);

--- a/Assets/ProceduralTerrain/CreateEnv/EnvironmentProfile.cs
+++ b/Assets/ProceduralTerrain/CreateEnv/EnvironmentProfile.cs
@@ -71,11 +71,19 @@ namespace CreateEnv
         // technical fields above stay the single source of truth for the loader.
         public SimpleEnvironmentSettings simple = new SimpleEnvironmentSettings();
 
+        // ── Group 6: Living Ecosystem ────────────────────────────────────────
+        // Off by default, so an environment saved before this feature existed loads
+        // with the ecosystem disabled and behaves exactly as it did. JsonUtility
+        // leaves a missing object at its field initialiser, so old .json files are
+        // read without migration.
+        public Ecosystem.EcosystemSettings ecosystem = new Ecosystem.EcosystemSettings();
+
         public EnvironmentProfile Clone()
         {
             var c = (EnvironmentProfile)MemberwiseClone();
             c.speciesDensity = (float[])speciesDensity.Clone();
             c.simple = simple != null ? simple.Clone() : new SimpleEnvironmentSettings();
+            c.ecosystem = ecosystem != null ? ecosystem.Clone() : new Ecosystem.EcosystemSettings();
             return c;
         }
     }

--- a/Assets/ProceduralTerrain/CreateEnv/UI/EnvironmentEditorUI.cs
+++ b/Assets/ProceduralTerrain/CreateEnv/UI/EnvironmentEditorUI.cs
@@ -140,6 +140,12 @@ namespace CreateEnv.UI
             Dropdown("Exploration area", SimpleEnvironmentSettings.ExplorationAreas,
                      s.explorationArea, v => { s.explorationArea = v; Edited(); });
             Slider("Visibility", s.visibility, v => { s.visibility = v; Edited(); });
+
+            // Living Ecosystem, appended below the existing sections (Design Doc §5).
+            // Built from these same row prefabs, so it inherits this form's styling.
+            Ecosystem.EcosystemFormSection.Build(
+                formContainer, headerRowPrefab, dropdownRowPrefab, sliderRowPrefab,
+                _work, Edited);
         }
 
         EnvironmentProfile Save()

--- a/Assets/Scripts/LivingEcosystem.meta
+++ b/Assets/Scripts/LivingEcosystem.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bcbfe85db5855cd4585e34e7e894f631
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/LivingEcosystem/Config.meta
+++ b/Assets/Scripts/LivingEcosystem/Config.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: aebaad0dd0fb60c4184fba5d660987ba
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/LivingEcosystem/Config/EcosystemFormSection.cs
+++ b/Assets/Scripts/LivingEcosystem/Config/EcosystemFormSection.cs
@@ -1,0 +1,274 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace CreateEnv.Ecosystem
+{
+    // The Living Ecosystem section of Create Environment (Design Document 5),
+    // appended below the current sections. No new screens, and no new art: it is
+    // built from the same three row prefabs the environment editor already uses, so
+    // it inherits that form's styling exactly.
+    //
+    // Every row is built once. Switching the feature off hides the rest of the
+    // section rather than rebuilding the form, and the warning lines are rewritten in
+    // place as choices are made. Nothing here destroys a row after the form is built,
+    // which keeps it clear of Unity's end-of-frame Destroy and its double-row hazard.
+    public static class EcosystemFormSection
+    {
+        // Called by EnvironmentEditorUI at the end of BuildForm.
+        public static void Build(RectTransform container,
+                                 GameObject headerRowPrefab,
+                                 GameObject dropdownRowPrefab,
+                                 GameObject sliderRowPrefab,
+                                 EnvironmentProfile profile,
+                                 Action edited)
+        {
+            if (container == null || profile == null) return;
+            if (headerRowPrefab == null || dropdownRowPrefab == null || sliderRowPrefab == null) return;
+
+            if (profile.ecosystem == null) profile.ecosystem = new EcosystemSettings();
+            var eco = profile.ecosystem;
+            eco.Clamp();
+
+            // Everything below the on/off switch, hidden as one group when off.
+            var body = new List<GameObject>(32);
+            TMP_Text warningsLabel = null;
+
+            void RefreshWarnings()
+            {
+                if (warningsLabel == null) return;
+                var warnings = EcosystemWarnings.For(eco.present);
+                if (warnings.Count == 0)
+                {
+                    warningsLabel.text = "This roster is balanced. Nothing obvious is missing.";
+                    warningsLabel.color = new Color32(0x66, 0x78, 0x8C, 0xFF);
+                    return;
+                }
+                var sb = new StringBuilder();
+                for (int i = 0; i < warnings.Count && i < 3; i++)
+                    sb.Append(i > 0 ? "\n" : "").Append("•  ").Append(warnings[i]);
+                warningsLabel.text = sb.ToString();
+                warningsLabel.color = new Color32(0xC2, 0x7A, 0x14, 0xFF);
+            }
+
+            void SetBodyVisible(bool visible)
+            {
+                for (int i = 0; i < body.Count; i++)
+                    if (body[i] != null) body[i].SetActive(visible);
+            }
+
+            Header(container, headerRowPrefab, "Living Ecosystem");
+
+            Dropdown(container, dropdownRowPrefab, "Enable living ecosystem",
+                     new[] { "Off", "On" }, eco.enabled ? 1 : 0,
+                     v =>
+                     {
+                         eco.enabled = v == 1;
+                         SetBodyVisible(eco.enabled);
+                         edited?.Invoke();
+                     });
+
+            body.Add(Note(container, headerRowPrefab,
+                          "Algae grow, animals graze and hunt, and populations rise and crash. " +
+                          "Turn this off and the environment behaves exactly as it does today."));
+
+            // ── Which organisms are present? ─────────────────────────────────
+            body.Add(Header(container, headerRowPrefab, "Which organisms are present?"));
+
+            BuildGroup(container, headerRowPrefab, dropdownRowPrefab, eco, edited, RefreshWarnings,
+                       body, "Producers", TrophicLevel.Producer);
+            BuildGroup(container, headerRowPrefab, dropdownRowPrefab, eco, edited, RefreshWarnings,
+                       body, "Plant eaters", TrophicLevel.PlantEater);
+            BuildGroup(container, headerRowPrefab, dropdownRowPrefab, eco, edited, RefreshWarnings,
+                       body, "Hunters", TrophicLevel.Hunter, TrophicLevel.TopPredator);
+
+            // Guard rails, not blocks: the learner may always build an unbalanced
+            // reef, but never without being told what it will do.
+            var warningRow = Note(container, headerRowPrefab, "");
+            warningsLabel = Find<TMP_Text>(warningRow, "Label");
+            body.Add(warningRow);
+            RefreshWarnings();
+
+            // ── Conditions ───────────────────────────────────────────────────
+            body.Add(Header(container, headerRowPrefab, "Conditions"));
+
+            body.Add(Dropdown(container, dropdownRowPrefab, "Starting life",
+                     EcosystemSettings.StartingLifeOptions, eco.startingLife,
+                     v => { eco.startingLife = v; edited?.Invoke(); }));
+
+            body.Add(Slider(container, sliderRowPrefab, "Water temperature",
+                     EcosystemBounds.Temperature.Normalize(eco.temperatureC),
+                     t =>
+                     {
+                         eco.temperatureC = EcosystemBounds.Temperature.Denormalize(t);
+                         edited?.Invoke();
+                         return eco.temperatureC.ToString("0.#") + " °C";
+                     },
+                     eco.temperatureC.ToString("0.#") + " °C"));
+
+            body.Add(Slider(container, sliderRowPrefab, "Water acidity",
+                     EcosystemBounds.Acidity.Normalize(eco.acidityPh),
+                     t =>
+                     {
+                         eco.acidityPh = EcosystemBounds.Acidity.Denormalize(t);
+                         edited?.Invoke();
+                         return "pH " + eco.acidityPh.ToString("0.00");
+                     },
+                     "pH " + eco.acidityPh.ToString("0.00")));
+
+            body.Add(Dropdown(container, dropdownRowPrefab, "Time speed",
+                     EcosystemSettings.SpeedOptions, eco.speed,
+                     v => { eco.speed = v; edited?.Invoke(); }));
+
+            // ── Predict, observe, compare ────────────────────────────────────
+            body.Add(Header(container, headerRowPrefab, EcosystemWarnings.PredictionQuestion));
+
+            var options = new List<string> { "I would rather not say" };
+            options.AddRange(EcosystemWarnings.PredictionOptions);
+            body.Add(Dropdown(container, dropdownRowPrefab, "Your prediction",
+                     options.ToArray(), Mathf.Clamp(eco.predictionIndex + 1, 0, options.Count - 1),
+                     v => { eco.predictionIndex = v - 1; edited?.Invoke(); }));
+
+            body.Add(Note(container, headerRowPrefab,
+                     "One tick is one day. At Normal that is 2 seconds; at Fast, a quarter of a second. " +
+                     "You can change any of this from inside the scene and watch it respond."));
+
+            SetBodyVisible(eco.enabled);
+        }
+
+        static void BuildGroup(RectTransform container, GameObject headerPrefab, GameObject dropdownPrefab,
+                               EcosystemSettings eco, Action edited, Action refreshWarnings,
+                               List<GameObject> body, string heading, params TrophicLevel[] levels)
+        {
+            body.Add(Note(container, headerPrefab, heading));
+
+            var all = SpeciesLibrary.All;
+            for (int i = 0; i < all.Length; i++)
+            {
+                bool inGroup = false;
+                foreach (var level in levels) if (all[i].level == level) inGroup = true;
+                if (!inGroup) continue;
+
+                int index = i;
+                body.Add(Dropdown(container, dropdownPrefab, all[i].commonName,
+                         new[] { "Removed", "Present" },
+                         eco.IsPresent(index) ? 1 : 0,
+                         v =>
+                         {
+                             if (eco.present != null && index < eco.present.Length)
+                                 eco.present[index] = v == 1;
+                             edited?.Invoke();
+                             // The warning lines follow the choice as it is made.
+                             refreshWarnings?.Invoke();
+                         }));
+            }
+        }
+
+        // ── Row builders (the editor's own prefabs, then bound) ──────────────
+        static GameObject Header(RectTransform container, GameObject prefab, string text)
+        {
+            var row = UnityEngine.Object.Instantiate(prefab, container);
+            SetText(row, "Label", text);
+            return row;
+        }
+
+        // A wrapping note. Built from scratch rather than from the header prefab:
+        // that prefab's label sits in a fixed-height row, so a note long enough to
+        // wrap overflows and prints on top of whatever comes next. Here the text
+        // component IS the row, so TextMeshPro reports its own preferred height to
+        // the surrounding vertical layout and the row grows to fit.
+        //
+        // The font is borrowed from the prefab so it still matches the form.
+        static GameObject Note(RectTransform container, GameObject prefab, string text, Color? colour = null)
+        {
+            var template = Find<TMP_Text>(prefab, "Label");
+
+            var row = new GameObject("Note", typeof(RectTransform));
+            row.transform.SetParent(container, false);
+
+            var label = row.AddComponent<TextMeshProUGUI>();
+            if (template != null)
+            {
+                label.font = template.font;
+                label.fontSize = Mathf.Max(12f, template.fontSize * 0.78f);
+            }
+            else
+            {
+                label.fontSize = 14f;
+            }
+
+            label.text = text;
+            label.color = colour ?? new Color32(0x66, 0x78, 0x8C, 0xFF);
+            label.textWrappingMode = TextWrappingModes.Normal;
+            label.alignment = TextAlignmentOptions.TopLeft;
+            label.margin = new Vector4(2f, 4f, 2f, 4f);
+            label.raycastTarget = false;
+
+            // The form sizes its rows from LayoutElement, so the row has to measure
+            // its own wrapped text and report a height back.
+            row.AddComponent<LayoutElement>();
+            row.AddComponent<NoteAutoHeight>();
+
+            return row;
+        }
+
+        static GameObject Dropdown(RectTransform container, GameObject prefab, string caption,
+                                   string[] options, int value, Action<int> onChange)
+        {
+            var row = UnityEngine.Object.Instantiate(prefab, container);
+            SetText(row, "Label", caption);
+
+            var dd = Find<TMP_Dropdown>(row, "Dropdown");
+            if (dd == null) return row;
+
+            dd.ClearOptions();
+            dd.AddOptions(new List<string>(options));
+            dd.SetValueWithoutNotify(Mathf.Clamp(value, 0, options.Length - 1));
+            dd.onValueChanged.RemoveAllListeners();
+            dd.onValueChanged.AddListener(v => onChange?.Invoke(v));
+            return row;
+        }
+
+        // Like the editor's own slider row, but the value text is formatted by the
+        // caller so it can read "24 °C" or "pH 8.10" instead of a percentage.
+        static GameObject Slider(RectTransform container, GameObject prefab, string caption,
+                                 float normalized, Func<float, string> onChange, string initialText)
+        {
+            var row = UnityEngine.Object.Instantiate(prefab, container);
+            SetText(row, "Label", caption);
+
+            var valueText = Find<TMP_Text>(row, "Value");
+            var slider = Find<Slider>(row, "Slider");
+            if (slider == null) return row;
+
+            slider.minValue = 0f;
+            slider.maxValue = 1f;
+            slider.wholeNumbers = false;
+            slider.SetValueWithoutNotify(Mathf.Clamp01(normalized));
+            if (valueText != null) valueText.text = initialText;
+
+            slider.onValueChanged.RemoveAllListeners();
+            slider.onValueChanged.AddListener(v =>
+            {
+                string text = onChange != null ? onChange(v) : null;
+                if (valueText != null && text != null) valueText.text = text;
+            });
+            return row;
+        }
+
+        static void SetText(GameObject root, string child, string value)
+        {
+            var t = Find<TMP_Text>(root, child);
+            if (t != null) t.text = value;
+        }
+
+        static T Find<T>(GameObject root, string child) where T : Component
+        {
+            var t = root.transform.Find(child);
+            return t != null ? t.GetComponent<T>() : null;
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Config/EcosystemFormSection.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Config/EcosystemFormSection.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fd2c8cba3cf60d5419b83619e9c3a8b7

--- a/Assets/Scripts/LivingEcosystem/Config/NoteAutoHeight.cs
+++ b/Assets/Scripts/LivingEcosystem/Config/NoteAutoHeight.cs
@@ -1,0 +1,57 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace CreateEnv.Ecosystem
+{
+    // Sizes a wrapping note row to its text.
+    //
+    // The environment builder's form lays its rows out with a VerticalLayoutGroup and
+    // each row prefab declares a fixed height through a LayoutElement. A warning line
+    // that wraps to three lines therefore overflows its row and prints on top of the
+    // next one. This measures the text at whatever width the row actually ends up
+    // with and writes that back to the LayoutElement.
+    //
+    // It only recomputes when the width changes, so it costs nothing once settled.
+    [RequireComponent(typeof(RectTransform))]
+    [RequireComponent(typeof(LayoutElement))]
+    public class NoteAutoHeight : MonoBehaviour
+    {
+        TMP_Text _text;
+        LayoutElement _element;
+        RectTransform _rect;
+        float _lastWidth = -1f;
+        string _lastText;
+
+        void Awake()
+        {
+            _rect = (RectTransform)transform;
+            _text = GetComponent<TMP_Text>();
+            _element = GetComponent<LayoutElement>();
+        }
+
+        void OnEnable() => _lastWidth = -1f;
+
+        void LateUpdate()
+        {
+            if (_text == null || _element == null) return;
+
+            float width = _rect.rect.width;
+            // Width is zero until the surrounding layout has run at least once.
+            if (width <= 1f) return;
+
+            if (Mathf.Abs(width - _lastWidth) < 0.5f && _text.text == _lastText) return;
+            _lastWidth = width;
+            _lastText = _text.text;
+
+            float height = _text.GetPreferredValues(_text.text, width, 0f).y;
+            height = Mathf.Max(24f, height + 10f);
+
+            _element.preferredHeight = height;
+            _element.minHeight = height;
+
+            if (_rect.parent is RectTransform parent)
+                LayoutRebuilder.MarkLayoutForRebuild(parent);
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Config/NoteAutoHeight.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Config/NoteAutoHeight.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ebcbee4e5d0778941a204b3abedada99

--- a/Assets/Scripts/LivingEcosystem/Data.meta
+++ b/Assets/Scripts/LivingEcosystem/Data.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d3928d326efc92c46a19f7e9cc741195
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/LivingEcosystem/Data/EcosystemBounds.cs
+++ b/Assets/Scripts/LivingEcosystem/Data/EcosystemBounds.cs
@@ -1,0 +1,78 @@
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem
+{
+    // The guardrail for the ecosystem half of a profile, matching the role
+    // EnvironmentBounds plays for the terrain half. Every learner-facing value has
+    // a Range here; the UI builds its sliders from these Ranges, so the form cannot
+    // express an out-of-range value, and Clamp() is the second line of defence on
+    // every load and every save.
+    public static class EcosystemBounds
+    {
+        public struct Range
+        {
+            public readonly float Min, Max, Default, Step;
+            public Range(float min, float max, float def, float step = 0f)
+            { Min = min; Max = max; Default = def; Step = step; }
+
+            public float Clamp(float v)
+            {
+                v = Mathf.Clamp(v, Min, Max);
+                if (Step > 0f) v = Min + Mathf.Round((v - Min) / Step) * Step;
+                return Mathf.Clamp(v, Min, Max);
+            }
+
+            // Where v sits in the range, 0..1. Used to drive the 0..1 sliders the
+            // builder form is made of.
+            public float Normalize(float v) => Max > Min ? Mathf.Clamp01((v - Min) / (Max - Min)) : 0f;
+            public float Denormalize(float t) => Clamp(Mathf.Lerp(Min, Max, Mathf.Clamp01(t)));
+        }
+
+        // Shallow Cabo Verde water runs roughly 22–27 °C through the year. The range
+        // is widened at both ends so the learner can push the system into bleaching
+        // territory and see it respond — the point of the control.
+        public static readonly Range Temperature = new Range(18f, 32f, 24f, 0.5f);
+
+        // Present-day surface pH is about 8.1. 7.7 is the low end of end-of-century
+        // projections; 8.3 is roughly pre-industrial.
+        public static readonly Range Acidity = new Range(7.6f, 8.3f, 8.1f, 0.05f);
+
+        // ── Environmental response curves ────────────────────────────────────
+        // Kept here, next to the ranges they read from, so retuning the biology and
+        // retuning the limits happen in one file.
+
+        // Growth multiplier on producers from temperature. Peaks near 26 °C and
+        // falls away on both sides; above the bleaching threshold the coral's
+        // symbionts are expelled and its capacity collapses (handled per-species
+        // through SpeciesDefinition.heatSensitivity).
+        public static float TemperatureFactor(float celsius, float optimum, float tolerance)
+        {
+            float d = (celsius - optimum) / Mathf.Max(0.01f, tolerance);
+            return Mathf.Clamp01(Mathf.Exp(-d * d));
+        }
+
+        // Metabolic cost rises with temperature for cold-blooded animals: warmer
+        // water means more food is needed simply to stay alive (Literature §2.9).
+        // ~10 % more demand per degree above the reference, Q10-flavoured but linear
+        // enough to stay legible.
+        public static float MetabolicFactor(float celsius)
+        {
+            return Mathf.Clamp(1f + (celsius - 24f) * 0.075f, 0.5f, 2.2f);
+        }
+
+        // Acidification makes calcium carbonate skeletons harder to build, so it hits
+        // calcifiers first and leaves soft-bodied organisms nearly untouched
+        // (Literature §2.9). 1 = unaffected at present-day pH.
+        public static float CalcificationFactor(float ph, float calcifierWeight)
+        {
+            if (calcifierWeight <= 0f) return 1f;
+            float deficit = Mathf.Clamp01((8.1f - ph) / 0.5f); // 0 at pH 8.1, 1 at pH 7.6
+            return Mathf.Clamp01(1f - deficit * calcifierWeight);
+        }
+
+        // Light at 5–20 m on a bright shallow Cabo Verde reef. Held constant in this
+        // release — it exists as a term so the equations match the design document
+        // and a day/night cycle can be added later without touching them.
+        public const float Light = 1f;
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Data/EcosystemBounds.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Data/EcosystemBounds.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3cd220e543126c343884fb59b9810ac6

--- a/Assets/Scripts/LivingEcosystem/Data/EcosystemSettings.cs
+++ b/Assets/Scripts/LivingEcosystem/Data/EcosystemSettings.cs
@@ -1,0 +1,81 @@
+using System;
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem
+{
+    // The user-facing half of the Living Ecosystem: five controls and nothing else.
+    // Mirrors SimpleEnvironmentSettings exactly — the editor UI edits this, the
+    // simulation reads it, and it rides inside EnvironmentProfile so it is saved,
+    // loaded and cloned by machinery that already exists.
+    //
+    // Design Document §5. Five controls is the whole set; additions are out of scope.
+    [Serializable]
+    public class EcosystemSettings
+    {
+        public static readonly string[] StartingLifeOptions = { "Few", "Balanced", "Many" };
+        public static readonly string[] SpeedOptions        = { "Paused", "Normal", "Fast" };
+
+        // Seconds of real time per simulated day, indexed by speed. Paused never ticks.
+        public static readonly float[] SecondsPerDay = { 0f, 2f, 0.25f };
+
+        // Multiplier on every pool's starting stock, indexed by startingLife.
+        public static readonly float[] StartingLifeScale = { 0.45f, 1f, 1.6f };
+
+        // ── The five controls ────────────────────────────────────────────────
+        public bool enabled = false;
+
+        // One flag per species, indexed by SpeciesLibrary order. Unchecking a
+        // species seeds it at zero and locks it there — no new simulation logic.
+        public bool[] present = SpeciesLibrary.AllPresent();
+
+        public int   startingLife = 1;     // Balanced
+        public float temperatureC = 24f;   // Cabo Verde shallow-water annual mean
+        public float acidityPh    = 8.1f;  // present-day open-ocean surface pH
+        public int   speed        = 1;     // Normal
+
+        // ── Prediction prompt (Design Document §5.1) ─────────────────────────
+        // What the learner predicted before entering, remembered so the outcome can
+        // be compared against it afterwards. -1 = no prediction made.
+        public int predictionIndex = -1;
+
+        public float SecondsPerSimDay => SecondsPerDay[Mathf.Clamp(speed, 0, SpeedOptions.Length - 1)];
+        public bool  IsPaused         => Mathf.Clamp(speed, 0, SpeedOptions.Length - 1) == 0;
+
+        public bool IsPresent(int speciesIndex)
+        {
+            if (present == null || speciesIndex < 0 || speciesIndex >= present.Length)
+                return false;
+            return present[speciesIndex];
+        }
+
+        public void Clamp()
+        {
+            startingLife = Mathf.Clamp(startingLife, 0, StartingLifeOptions.Length - 1);
+            speed        = Mathf.Clamp(speed, 0, SpeedOptions.Length - 1);
+            temperatureC = EcosystemBounds.Temperature.Clamp(temperatureC);
+            acidityPh    = EcosystemBounds.Acidity.Clamp(acidityPh);
+
+            // The species list is the one field that can go stale: a profile saved
+            // before a species was added would carry a short array. Grow it, keeping
+            // the learner's existing choices and defaulting anything new to present.
+            int n = SpeciesLibrary.Count;
+            if (present == null || present.Length != n)
+            {
+                var grown = SpeciesLibrary.AllPresent();
+                if (present != null)
+                    for (int i = 0; i < Mathf.Min(present.Length, n); i++)
+                        grown[i] = present[i];
+                present = grown;
+            }
+
+            if (predictionIndex < -1) predictionIndex = -1;
+        }
+
+        public EcosystemSettings Clone()
+        {
+            var c = (EcosystemSettings)MemberwiseClone();
+            c.present = present != null ? (bool[])present.Clone() : SpeciesLibrary.AllPresent();
+            return c;
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Data/EcosystemSettings.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Data/EcosystemSettings.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1a83dfdf7171682498323b36c76a29c7

--- a/Assets/Scripts/LivingEcosystem/Data/SpeciesDefinition.cs
+++ b/Assets/Scripts/LivingEcosystem/Data/SpeciesDefinition.cs
@@ -1,0 +1,133 @@
+using System;
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem
+{
+    // How an organism moves, which is a property of the animal and not of its
+    // trophic level. A coral is a producer in this model but it is a colony of
+    // polyps on a rigid limestone skeleton: it does not sway, and a swaying one
+    // reads as a plant, which is the exact misconception the info card corrects.
+    public enum MotionKind
+    {
+        Fixed = 0,   // rigid and rooted: the coral
+        Sway  = 1,   // flexible and rooted: both algae
+        Crawl = 2,   // moves slowly over the seabed: urchin, limpet, lobster
+        Swim  = 3,   // free in the water column: parrotfish, octopus, shark
+    }
+
+    public enum TrophicLevel
+    {
+        Producer   = 0,
+        PlantEater = 1,
+        Hunter     = 2,
+        TopPredator = 3,
+    }
+
+    // One species, as data. Everything the simulation needs and everything the info
+    // card shows, in one place, so retuning the biology never means touching code.
+    //
+    // Units: one biomass unit is 1 kg wet mass over the modelled reef patch (about
+    // 100 m2 of Cabo Verde shallow sand and rock). Appetites are per individual per
+    // day and sit close to real fractions of body mass. Rates are per simulated day.
+    [Serializable]
+    public class SpeciesDefinition
+    {
+        // ── Identity ─────────────────────────────────────────────────────────
+        public string id;
+        public string commonName;      // what the interface calls it
+        public string scientificName;
+        public TrophicLevel level;
+
+        // ── Producer terms (level == Producer) ───────────────────────────────
+        public float growthRate;       // logistic r, per day
+        public float baseCapacity;     // K before light/temperature/acidity
+        public float naturalLoss;      // fraction shed per day, feeds the detritus pool
+        public float recruitment;      // spore/drift arrival as a fraction of K per day
+        public float optimumTemperature;
+        public float temperatureTolerance;
+        public float bleachingThresholdC;   // 0 = does not bleach
+
+        // ── Consumer terms (everything else) ─────────────────────────────────
+        public float appetite;         // biomass wanted per individual per day
+        public float assimilation;     // share of intake that becomes usable energy
+        public float livingCost;       // energy spent per individual per day
+        public float birthRate;        // max share added per day when well fed
+        public float starveRate;       // max share lost per day when underfed
+        public float ceiling;          // most individuals the patch can hold
+        public float unitMass;         // biomass of one individual
+        public float presence;         // share of days actually on this patch
+        public float detritusFraction; // share of demand met from detritus
+        public bool  transient;        // present or absent, never a local population
+
+        // ── Shared ───────────────────────────────────────────────────────────
+        public float calcifierWeight;  // 0 = soft-bodied, 1 = fully carbonate-skeletoned
+        public float refuge;           // biomass no predator can ever reach
+        public float startingStock;    // biomass for producers, count for consumers
+
+        // ── Presentation ─────────────────────────────────────────────────────
+        public Color tint;             // pyramid bars, readout dots, minimap
+        public float modelHeightMeters;// drawn size, used by the renderer
+        public float individualsPerModel; // how many animals one drawn model stands for
+
+        // Where this species lives in the water column.
+        //
+        // Attached life — both algae, the coral, the urchin, the limpet, the lobster —
+        // is fixed to the bottom: seated with its underside on the seabed and tilted
+        // to the slope. Everything else swims at a height above the seabed, in metres.
+        //
+        // Measured from the seabed rather than as a share of the water column, because
+        // the seabed is directly underfoot and always known, whereas the water surface
+        // is placed independently of the terrain and the two can disagree.
+        public bool  attachedToSeabed;
+        public float seabedClearanceMin;
+        public float seabedClearanceMax;
+
+        public MotionKind motion;
+
+        [Tooltip("How far a crawler wanders from where it settled, in metres, and " +
+                 "how much a swimmer rises and falls within its band.")]
+        public float roamRadius;
+        public float verticalRoam;
+
+        // ── Info card (traceable to the Literature Document) ─────────────────
+        public string appearance;
+        public string habitat;
+        public string diet;
+        public string roleInModel;
+        public string iucnStatus;
+        public string regionalStatus;
+        [TextArea] public string oneThingWorthTelling;
+        [TextArea] public string simplificationNote;
+
+        public bool IsProducer => level == TrophicLevel.Producer;
+        public bool IsConsumer => level != TrophicLevel.Producer;
+        public bool CanBleach  => bleachingThresholdC > 0f;
+
+        public SpeciesDefinition Clone() => (SpeciesDefinition)MemberwiseClone();
+    }
+
+    // One predator-prey edge. Kept as a table so designers can retune the web
+    // without a code change (Design Document 2.3).
+    [Serializable]
+    public class FoodLink
+    {
+        public int predator;
+        public int prey;
+
+        [Tooltip("Relative share of this predator's demand aimed at this prey.")]
+        public float preference;
+
+        [Tooltip("Prey biomass at which this predator gets half of what it wants. " +
+                 "Low means a relentless forager that keeps finding food even when it " +
+                 "is thin on the ground.")]
+        public float halfSaturation;
+
+        public FoodLink(int predator, int prey, float preference, float halfSaturation)
+        {
+            this.predator = predator;
+            this.prey = prey;
+            this.preference = preference;
+            this.halfSaturation = halfSaturation;
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Data/SpeciesDefinition.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Data/SpeciesDefinition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e9e8b4a6834d95f4f937954dd38d3032

--- a/Assets/Scripts/LivingEcosystem/Data/SpeciesLibrary.cs
+++ b/Assets/Scripts/LivingEcosystem/Data/SpeciesLibrary.cs
@@ -1,0 +1,435 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem
+{
+    // The Cabo Verde roster and the food web that connects it.
+    //
+    // Defined in code so the feature works with no asset authoring, and overridable
+    // by dropping a SpeciesLibraryAsset named "SpeciesLibrary" into a Resources
+    // folder — the same pattern LifePackLibrary already uses. Retuning the biology
+    // therefore never needs a rebuild, which is what the milestone document asks for.
+    //
+    // Every rate here was solved rather than guessed: the balanced roster is a fixed
+    // point of the simulation, holding its starting populations to within a fraction
+    // of a percent over 400 simulated days. Changing one number moves that fixed
+    // point, so re-run the balance report in
+    // Tools > Living Ecosystem > Balance Report after any edit.
+    //
+    // Content (appearance, habitat, conservation status, the "one thing worth
+    // telling") is taken from the Living Ecosystem Literature Document v1, Part 4.
+    // Nothing here should be invented; add it to that document first.
+    public static class SpeciesLibrary
+    {
+        // Indices are the wire format for EcosystemSettings.present[] and for the
+        // save file. Append new species at the end; never reorder.
+        public const int Halimeda    = 0;
+        public const int Padina      = 1;
+        public const int Coral       = 2;
+        public const int Parrotfish  = 3;
+        public const int Urchin      = 4;
+        public const int Limpet      = 5;
+        public const int Lobster     = 6;
+        public const int Octopus     = 7;
+        public const int TigerShark  = 8;
+
+        public const int Count = 9;
+
+        // Bump this whenever a field is added to SpeciesDefinition or the roster
+        // layout changes.
+        //
+        // A SpeciesLibrary asset in Resources overrides this code entirely. That is
+        // the point of it — but an asset written before a field existed deserializes
+        // that field as zero, and then silently overrides the code with it. That is
+        // exactly what happened: an asset generated from the first roster kept
+        // reporting motion = Fixed and zero seabed clearance for every species, so
+        // every organism sat motionless on the seabed no matter what this file said,
+        // and no amount of editing here changed anything. The version stamp makes a
+        // stale asset announce itself and step aside instead of failing silently.
+        public const int RosterVersion = 3;
+
+        // How far above 1.0 the supply/need ratio must sit for full breeding, and how
+        // far below for full starvation mortality.
+        public const float SurplusForFullBreeding = 0.35f;
+        public const float DeficitForFullDeath    = 0.50f;
+
+        // Share of what dies that reaches the seafloor rather than being eaten, and
+        // the daily share of the detritus pool that bacteria return to the water.
+        public const float DetritusFromDeath   = 0.80f;
+        public const float DetritusFromGrazing = 0.20f;
+        public const float DetritusRemineralised = 0.015f;
+
+        static SpeciesDefinition[] _cached;
+        static FoodLink[] _cachedWeb;
+        static bool _triedAsset;
+
+        public static SpeciesDefinition[] All
+        {
+            get { EnsureLoaded(); return _cached; }
+        }
+
+        public static FoodLink[] Web
+        {
+            get { EnsureLoaded(); return _cachedWeb; }
+        }
+
+        public static SpeciesDefinition Get(int index)
+        {
+            EnsureLoaded();
+            return index >= 0 && index < _cached.Length ? _cached[index] : null;
+        }
+
+        public static string NameOf(int index)
+        {
+            var s = Get(index);
+            return s != null ? s.commonName : "unknown";
+        }
+
+        public static bool[] AllPresent()
+        {
+            var flags = new bool[Count];
+            for (int i = 0; i < Count; i++) flags[i] = true;
+            return flags;
+        }
+
+        // Reloads on next access. Called by the editor tools after an asset edit.
+        public static void Invalidate()
+        {
+            _cached = null;
+            _cachedWeb = null;
+            _triedAsset = false;
+        }
+
+        static void EnsureLoaded()
+        {
+            if (_cached != null) return;
+
+            if (!_triedAsset)
+            {
+                _triedAsset = true;
+                var asset = Resources.Load<SpeciesLibraryAsset>("SpeciesLibrary");
+                if (asset != null)
+                {
+                    if (asset.rosterVersion != RosterVersion)
+                    {
+                        Debug.LogWarning(
+                            $"[SpeciesLibrary] Ignoring Resources/SpeciesLibrary: it was written " +
+                            $"against roster version {asset.rosterVersion}, but this build expects " +
+                            $"{RosterVersion}. Fields added since would load as zero and silently " +
+                            $"override the code — which is how every organism ended up motionless " +
+                            $"on the seabed. Delete the asset, or regenerate it from " +
+                            $"Tools > Living Ecosystem > Create Species Library Asset.");
+                    }
+                    else if (asset.species == null || asset.species.Length != Count)
+                    {
+                        Debug.LogWarning($"[SpeciesLibrary] Ignoring Resources/SpeciesLibrary: expected " +
+                                         $"{Count} species, found {asset.species?.Length ?? 0}.");
+                    }
+                    else
+                    {
+                        _cached = asset.species;
+                        _cachedWeb = asset.web != null && asset.web.Length > 0 ? asset.web : BuildWeb();
+                        Debug.Log("[SpeciesLibrary] Using the roster from Resources/SpeciesLibrary.");
+                        return;
+                    }
+                }
+            }
+
+            _cached = BuildDefault();
+            _cachedWeb = BuildWeb();
+        }
+
+        // ── The food web (Design Document 2.3) ───────────────────────────────
+        static FoodLink[] BuildWeb()
+        {
+            return new[]
+            {
+                // Grazers on the two algae. The coral is not grazed in this model.
+                new FoodLink(Parrotfish, Halimeda, 0.53f, 18f),
+                new FoodLink(Parrotfish, Padina,   0.42f, 18f),
+                // Sparisoma also takes juvenile urchins, which is part of why losing
+                // parrotfish lets a barren form (Clemente et al., Canary Islands).
+                new FoodLink(Parrotfish, Urchin,   0.05f, 10f),
+
+                new FoodLink(Urchin, Halimeda, 0.50f, 6f),
+                new FoodLink(Urchin, Padina,   0.50f, 6f),
+
+                new FoodLink(Limpet, Halimeda, 0.40f, 8f),
+                new FoodLink(Limpet, Padina,   0.60f, 8f),
+
+                // The lobster is an omnivore; the rest of its demand is detritus.
+                new FoodLink(Lobster, Halimeda, 0.35f, 12f),
+                new FoodLink(Lobster, Padina,   0.25f, 12f),
+
+                new FoodLink(Octopus, Lobster, 0.80f, 4f),
+                new FoodLink(Octopus, Limpet,  0.20f, 1f),
+
+                new FoodLink(TigerShark, Parrotfish, 0.30f, 12f),
+                new FoodLink(TigerShark, Urchin,     0.55f, 8f),
+                new FoodLink(TigerShark, Octopus,    0.15f, 10f),
+            };
+        }
+
+        // ── The roster ───────────────────────────────────────────────────────
+        static SpeciesDefinition[] BuildDefault()
+        {
+            var list = new List<SpeciesDefinition>(Count);
+
+            list.Add(new SpeciesDefinition
+            {
+                id = "halimeda",
+                commonName = "Calcareous green alga",
+                scientificName = "Halimeda sp.",
+                level = TrophicLevel.Producer,
+                growthRate = 0.16f, baseCapacity = 140f, naturalLoss = 0.020f, recruitment = 0.004f,
+                optimumTemperature = 26f, temperatureTolerance = 7f,
+                calcifierWeight = 0.55f, startingStock = 92.44f,
+                tint = new Color(0.44f, 0.76f, 0.42f),
+                // A low bushy clump, 10-25 cm across.
+                modelHeightMeters = 0.22f, individualsPerModel = 12f,
+                attachedToSeabed = true, motion = MotionKind.Sway,
+                appearance = "Chains of small flat green segments, each stiffened with limestone, growing in low bushy clumps.",
+                habitat = "Shallow sand and rubble in warm seas worldwide.",
+                diet = "Photosynthesis — it makes its own food from sunlight.",
+                roleInModel = "The quickest producer to rebound. Keeps the ecosystem alive through moderate grazing.",
+                iucnStatus = "Not individually assessed",
+                regionalStatus = "Common on Cabo Verde shallow sand",
+                oneThingWorthTelling =
+                    "This alga builds limestone into its own tissue. When it dies the soft parts rot away and " +
+                    "the limestone segments fall to the seafloor as pale sand. A great deal of tropical white " +
+                    "sand is the remains of algae like this one. You are standing on it.",
+                simplificationNote = "Given at genus level. The specific Cabo Verde species is still to be confirmed against a regional checklist.",
+            });
+
+            list.Add(new SpeciesDefinition
+            {
+                id = "padina",
+                commonName = "Fan alga",
+                scientificName = "Padina sp.",
+                level = TrophicLevel.Producer,
+                growthRate = 0.16f, baseCapacity = 100f, naturalLoss = 0.018f, recruitment = 0.006f,
+                optimumTemperature = 25f, temperatureTolerance = 7.5f,
+                calcifierWeight = 0.25f, startingStock = 73.81f,
+                tint = new Color(0.72f, 0.62f, 0.34f),
+                // Fan blades are small — a hand's width.
+                modelHeightMeters = 0.16f, individualsPerModel = 12f,
+                attachedToSeabed = true, motion = MotionKind.Sway,
+                appearance = "Thin fan- or funnel-shaped blades, pale brown with fine concentric banding, often with a chalky white surface.",
+                habitat = "Shallow rock and rubble in warm and warm-temperate seas.",
+                diet = "Photosynthesis — it makes its own food from sunlight.",
+                roleInModel = "The opportunist. First to spread across space that grazing or coral loss opens up.",
+                iucnStatus = "Not individually assessed",
+                regionalStatus = "Common on Cabo Verde shallow rock",
+                oneThingWorthTelling =
+                    "When grazing animals are removed, this is the alga that takes over. It grows over coral and " +
+                    "blocks its light. A reef shifting from coral-dominated to algae-dominated is one of the " +
+                    "most-studied problems in reef ecology, and it usually begins with the loss of grazers rather " +
+                    "than with anything happening to the coral itself.",
+                simplificationNote = "Given at genus level. The specific Cabo Verde species is still to be confirmed against a regional checklist.",
+            });
+
+            list.Add(new SpeciesDefinition
+            {
+                id = "siderastrea-radians",
+                commonName = "Lesser starlet coral",
+                scientificName = "Siderastrea radians",
+                level = TrophicLevel.Producer,
+                growthRate = 0.010f, baseCapacity = 60f, naturalLoss = 0.002f, recruitment = 0.0004f,
+                optimumTemperature = 26.5f, temperatureTolerance = 5f,
+                bleachingThresholdC = 29.5f,
+                calcifierWeight = 0.90f, startingStock = 30.65f,
+                tint = new Color(0.52f, 0.60f, 0.51f),
+                modelHeightMeters = 0.30f, individualsPerModel = 10f,
+                attachedToSeabed = true, motion = MotionKind.Fixed,
+                appearance = "Small domes or encrusting sheets, grey to greenish-brown, rarely more than 30 cm across, with deeply pitted star-shaped cups.",
+                habitat = "Shallow water under 25 m, most common under 10 m. Forms pavements over shallow rock in Cabo Verde.",
+                diet = "Mostly sugars from the single-celled algae living in its tissue, topped up by catching small drifting animals at night. An organism that both photosynthesises and feeds is called a mixotroph — a coral is an animal, not a plant.",
+                roleInModel = "The bleaching indicator, and the demonstration of how slowly some things recover.",
+                iucnStatus = "Least Concern",
+                regionalStatus = "Forms pavements on shallow Cabo Verde rock",
+                oneThingWorthTelling =
+                    "This is one of the toughest corals in the Atlantic. It survives conditions that kill more " +
+                    "delicate reef-building species — murky water, wide temperature swings, being rolled loose " +
+                    "across the seafloor. That toughness is why it is still common while many showier corals are " +
+                    "in decline, and it is a useful counterweight to the idea that all corals are equally fragile.",
+                simplificationNote = "Bleaching here is modelled as a loss of growth and a faster wasting away above 29.5 °C. Bleached coral is not dead and recovers if the water cools quickly enough.",
+            });
+
+            list.Add(new SpeciesDefinition
+            {
+                id = "sparisoma-cretense",
+                commonName = "Parrotfish",
+                scientificName = "Sparisoma cretense",
+                level = TrophicLevel.PlantEater,
+                appetite = 0.170f, assimilation = 0.34f, livingCost = 0.03874f,
+                birthRate = 0.0220f, starveRate = 0.055f,
+                ceiling = 42f, unitMass = 1.20f, presence = 1f,
+                refuge = 3.0f, startingStock = 18f,
+                tint = new Color(0.90f, 0.45f, 0.38f),
+                modelHeightMeters = 0.45f, individualsPerModel = 3f,
+                seabedClearanceMin = 3.4f, seabedClearanceMax = 5.6f, motion = MotionKind.Swim, verticalRoam = 0.7f,
+                appearance = "Two distinct colour phases. Females are grey with a red saddle and yellow markings; terminal-phase males are reddish-brown and plainer. Up to about 50 cm.",
+                habitat = "Shallow rocky and vegetated bottoms. One of the two most common parrotfishes in Cabo Verde.",
+                diet = "Algae, scraped from rock with fused beak-like teeth. Also takes juvenile sea urchins.",
+                roleInModel = "The main grazer. Its removal is the fastest route to algal overgrowth.",
+                iucnStatus = "Not currently listed as threatened",
+                regionalStatus = "Locally fished",
+                oneThingWorthTelling =
+                    "Every one of these fish starts life as a female, and only the largest become males, changing " +
+                    "colour completely as they do. Sex is not fixed at birth for a great many fish. It is also why " +
+                    "size-selective fishing is dangerous for these species — take the biggest fish and you are " +
+                    "taking all the males.",
+                simplificationNote = "Sex change is described on this card but is not simulated; the model tracks numbers, not individuals.",
+            });
+
+            list.Add(new SpeciesDefinition
+            {
+                id = "diadema-africanum",
+                commonName = "Long-spined sea urchin",
+                scientificName = "Diadema africanum",
+                level = TrophicLevel.PlantEater,
+                appetite = 0.035f, assimilation = 0.30f, livingCost = 0.00764f,
+                birthRate = 0.0270f, starveRate = 0.038f,
+                ceiling = 400f, unitMass = 0.25f, presence = 1f,
+                detritusFraction = 0.20f,
+                refuge = 3.0f, startingStock = 45f,
+                calcifierWeight = 0.30f,
+                tint = new Color(0.14f, 0.12f, 0.19f),
+                modelHeightMeters = 0.24f, individualsPerModel = 8f,
+                attachedToSeabed = true, motion = MotionKind.Crawl, roamRadius = 0.7f,
+                appearance = "Dark globe with very long, fine, mobile black spines.",
+                habitat = "Shallow rocky bottoms across the eastern Atlantic archipelagos and West Africa.",
+                diet = "Algae, grazed continuously, plus detritus and encrusting material — which is why it keeps going once the algae are gone.",
+                roleInModel = "The runaway grazer. At high density it strips vegetation to bare rock.",
+                iucnStatus = "Not listed",
+                regionalStatus = "Has suffered severe mass-mortality events",
+                oneThingWorthTelling =
+                    "This urchin has been both villain and victim. Dense populations created bare barrens across " +
+                    "these islands for decades. Then, beginning in 2022, a disease swept through and killed most " +
+                    "of them, with some island populations falling by more than 99 percent. The cause is still not " +
+                    "fully understood. Losing a grazer that was itself a problem does not restore balance — it " +
+                    "produces a different imbalance, and the ecosystem is still adjusting.",
+                simplificationNote = "The 2022 mass-mortality disease is described on this card but is not simulated.",
+            });
+
+            list.Add(new SpeciesDefinition
+            {
+                id = "fissurella",
+                commonName = "Keyhole limpet",
+                scientificName = "Fissurella sp.",
+                level = TrophicLevel.PlantEater,
+                appetite = 0.004f, assimilation = 0.30f, livingCost = 0.00085f,
+                birthRate = 0.0327f, starveRate = 0.030f,
+                ceiling = 200f, unitMass = 0.05f, presence = 1f,
+                refuge = 0.30f, startingStock = 26f,
+                calcifierWeight = 0.45f,
+                tint = new Color(0.56f, 0.48f, 0.40f),
+                modelHeightMeters = 0.07f, individualsPerModel = 10f,
+                attachedToSeabed = true, motion = MotionKind.Crawl, roamRadius = 0.3f,
+                appearance = "Low conical shell with a small opening at the apex, giving the group its name.",
+                habitat = "Shallow rock. Cabo Verde holds several lineages found nowhere else.",
+                diet = "Algal film and turf, rasped from rock.",
+                roleInModel = "A slow, steady grazer and reliable octopus prey.",
+                iucnStatus = "Not individually assessed",
+                regionalStatus = "Endemic lineages are inherently vulnerable",
+                oneThingWorthTelling =
+                    "These limpets have young that drift only briefly before settling, so they rarely cross the " +
+                    "water between islands. Populations on different islands have been separated long enough to " +
+                    "become distinct species found on one island and nowhere else on Earth. Isolation makes new " +
+                    "species, and it also makes them fragile — a species that exists on one island can be lost entirely.",
+                simplificationNote = "Given at genus level. The specific Cabo Verde lineage is still to be confirmed.",
+            });
+
+            list.Add(new SpeciesDefinition
+            {
+                id = "panulirus-echinatus",
+                commonName = "Brown spiny lobster",
+                scientificName = "Panulirus echinatus",
+                level = TrophicLevel.PlantEater,
+                appetite = 0.030f, assimilation = 0.32f, livingCost = 0.00697f,
+                birthRate = 0.0595f, starveRate = 0.030f,
+                ceiling = 40f, unitMass = 0.80f, presence = 1f,
+                detritusFraction = 0.40f,
+                refuge = 2.0f, startingStock = 14f,
+                calcifierWeight = 0.35f,
+                tint = new Color(0.72f, 0.36f, 0.24f),
+                // Body plus those body-length antennae, which the mesh includes.
+                modelHeightMeters = 0.55f, individualsPerModel = 3f,
+                attachedToSeabed = true, motion = MotionKind.Crawl, roamRadius = 1.1f,
+                appearance = "Spiny-shelled lobster with long antennae and no large claws, dark brown with pale spots.",
+                habitat = "Rocky crevices in shallow water. A main coastal catch in Cabo Verde.",
+                diet = "Algae, detritus and small animals — genuinely an omnivore.",
+                roleInModel = "The octopus's principal prey, and the link that makes the shark's removal matter.",
+                iucnStatus = "Not listed",
+                regionalStatus = "Locally and commercially fished",
+                oneThingWorthTelling =
+                    "Spiny lobsters have no crushing claws. Their defence is armour, spines and a crevice to back " +
+                    "into. This is precisely why an octopus can take them — an octopus does not need to overpower " +
+                    "a lobster, only to reach into the crevice. Predator and prey are shaped by each other.",
+                simplificationNote = "Sits between plant eater and hunter in reality; the pyramid places it with the plant eaters.",
+            });
+
+            list.Add(new SpeciesDefinition
+            {
+                id = "octopus-vulgaris",
+                commonName = "Common octopus",
+                scientificName = "Octopus vulgaris",
+                level = TrophicLevel.Hunter,
+                appetite = 0.090f, assimilation = 0.36f, livingCost = 0.01739f,
+                birthRate = 0.0139f, starveRate = 0.050f,
+                ceiling = 9f, unitMass = 2.50f, presence = 1f,
+                refuge = 2.5f, startingStock = 5f,
+                tint = new Color(0.80f, 0.42f, 0.62f),
+                modelHeightMeters = 0.60f, individualsPerModel = 1f,
+                seabedClearanceMin = 0.20f, seabedClearanceMax = 1.10f, motion = MotionKind.Swim, verticalRoam = 0.9f,
+                appearance = "Soft-bodied, eight-armed, and able to change colour and skin texture almost instantly.",
+                habitat = "Rock, rubble and sand from the shore down to the shelf. Dens in crevices.",
+                diet = "Crustaceans and molluscs, occasionally fish.",
+                roleInModel = "The mesopredator — the mid-level hunter whose numbers rise when the shark above it is removed.",
+                iucnStatus = "Not listed as threatened",
+                regionalStatus = "Heavily and often unregulated fished",
+                oneThingWorthTelling =
+                    "The octopus changes colour and texture faster and more completely than almost any other " +
+                    "animal, using pigment sacs that muscles pull open and closed, reflective layers beneath, and " +
+                    "small muscles that raise bumps in the skin. The whole system is under direct nervous control, " +
+                    "which is why the change is nearly instant. It breeds once and then dies — a pattern called " +
+                    "semelparity, normal for almost all octopuses.",
+                simplificationNote = "Lives about a year in the wild; this reef runs faster than that. The handful of octopuses here are individuals with real genes, but a wild female lays tens of thousands of eggs and almost none survive - the broods here are two to four so that inheritance can be followed at all.",
+            });
+
+            list.Add(new SpeciesDefinition
+            {
+                id = "galeocerdo-cuvier",
+                commonName = "Tiger shark",
+                scientificName = "Galeocerdo cuvier",
+                level = TrophicLevel.TopPredator,
+                appetite = 4.0f, assimilation = 0.40f, livingCost = 0.13335f,
+                birthRate = 0f, starveRate = 0.012f,
+                ceiling = 2f, unitMass = 60f,
+                // A visitor, not a resident: it is on this patch about a fifth of the
+                // time, and it leaves rather than starves.
+                presence = 0.20f, transient = true,
+                refuge = 0f, startingStock = 1f,
+                tint = new Color(0.42f, 0.52f, 0.62f),
+                modelHeightMeters = 3.2f, individualsPerModel = 1f,
+                seabedClearanceMin = 1.5f, seabedClearanceMax = 2.9f, motion = MotionKind.Swim, verticalRoam = 0.5f,
+                appearance = "Commonly 3.3 to 4.3 m; females can exceed 5 m. Blunt snout and faint vertical barring that fades with age.",
+                habitat = "Coastal and oceanic. Individuals in Cabo Verde have been tracked across the full life cycle.",
+                diet = "Extremely broad — fish, turtles, seabirds, molluscs, crustaceans, carrion.",
+                roleInModel = "The transient apex predator whose absence reshapes everything below.",
+                iucnStatus = "Near Threatened",
+                regionalStatus = "Present in the eastern Atlantic from Morocco southward",
+                oneThingWorthTelling =
+                    "Reputation and behaviour do not match. Tracking work has repeatedly found tiger sharks " +
+                    "spending much of their time cruising shallow vegetated seafloor rather than patrolling open " +
+                    "water — so consistently that researchers have used camera-carrying tiger sharks to map " +
+                    "seafloor habitat that ships and satellites had missed. The animal is a survey instrument as " +
+                    "well as a predator. One female tagged in Cabo Verde completed a round trip across the " +
+                    "Atlantic of nearly 18,000 km.",
+                simplificationNote = "Highly migratory in reality. Modelled as present or absent rather than as a population, because it visits this patch rather than living on it.",
+            });
+
+            return list.ToArray();
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Data/SpeciesLibrary.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Data/SpeciesLibrary.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1bbd585924d605f4e97a8dcecf029c5a

--- a/Assets/Scripts/LivingEcosystem/Data/SpeciesLibraryAsset.cs
+++ b/Assets/Scripts/LivingEcosystem/Data/SpeciesLibraryAsset.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem
+{
+    // Optional override for the built-in roster. Create one via
+    // Assets > Create > Living Ecosystem > Species Library, put it in a Resources
+    // folder as "SpeciesLibrary", and the simulation reads it instead of the code
+    // defaults — so balancing needs no rebuild, which is what the milestone document
+    // asks for. Same pattern as LifePackLibrary.
+    //
+    // Use Tools > Living Ecosystem > Create Species Library Asset to generate one
+    // pre-filled with the built-in roster, then edit the numbers.
+    [CreateAssetMenu(menuName = "Living Ecosystem/Species Library", fileName = "SpeciesLibrary")]
+    public class SpeciesLibraryAsset : ScriptableObject
+    {
+        [Tooltip("Which version of the roster layout this asset was written against. " +
+                 "If it does not match SpeciesLibrary.RosterVersion the asset is " +
+                 "ignored, because fields added since would silently deserialize to " +
+                 "zero and quietly override the code.")]
+        public int rosterVersion;
+
+        [Tooltip("Must contain exactly SpeciesLibrary.Count entries, in the same order. " +
+                 "Order is the wire format for the organism picker; never reorder.")]
+        public SpeciesDefinition[] species;
+
+        [Tooltip("Predator/prey edges. Leave empty to use the built-in web.")]
+        public FoodLink[] web;
+
+        void OnValidate()
+        {
+            if (species != null && species.Length != SpeciesLibrary.Count)
+                Debug.LogWarning($"[SpeciesLibrary] Expected {SpeciesLibrary.Count} species, found " +
+                                 $"{species.Length}. The built-in roster will be used until this matches.", this);
+            SpeciesLibrary.Invalidate();
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Data/SpeciesLibraryAsset.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Data/SpeciesLibraryAsset.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 51ff1bee50e21d245b740d9cd0c59ded

--- a/Assets/Scripts/LivingEcosystem/Editor.meta
+++ b/Assets/Scripts/LivingEcosystem/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1bb5834c93b208e4d957142890e252a0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/LivingEcosystem/Editor/EcosystemBalanceWindow.cs
+++ b/Assets/Scripts/LivingEcosystem/Editor/EcosystemBalanceWindow.cs
@@ -1,0 +1,211 @@
+using System.Text;
+using UnityEditor;
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem.EditorTools
+{
+    // Runs the ecosystem headlessly and reports what it does.
+    //
+    // The milestone document names balancing as the main risk of this step and asks
+    // for every rate to live in data so tuning needs no rebuild. This is the other
+    // half of that: a way to check a change without entering play mode, putting on a
+    // headset, and waiting several simulated months.
+    //
+    // The scenarios are the milestone's own "Done when" clauses.
+    public class EcosystemBalanceWindow : EditorWindow
+    {
+        Vector2 _scroll;
+        string _report = "Press Run to simulate.";
+        int _days = 400;
+
+        [MenuItem("Tools/Living Ecosystem/Balance Report")]
+        static void Open()
+        {
+            var window = GetWindow<EcosystemBalanceWindow>(false, "Reef Balance", true);
+            window.minSize = new Vector2(680f, 460f);
+        }
+
+        void OnGUI()
+        {
+            EditorGUILayout.Space(6f);
+            EditorGUILayout.LabelField("Living Reef — balance report", EditorStyles.boldLabel);
+            EditorGUILayout.HelpBox(
+                "Simulates the reef without entering play mode. Run this after changing any " +
+                "rate in SpeciesLibrary or in a SpeciesLibrary asset.", MessageType.Info);
+
+            _days = EditorGUILayout.IntSlider("Days to simulate", _days, 60, 2000);
+
+            EditorGUILayout.BeginHorizontal();
+            if (GUILayout.Button("Run", GUILayout.Height(28f))) Run();
+            if (GUILayout.Button("Reload species data", GUILayout.Height(28f)))
+            {
+                SpeciesLibrary.Invalidate();
+                SpeciesVisualLibrary.Invalidate();
+                _report = "Species data reloaded.";
+            }
+            EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.Space(6f);
+            _scroll = EditorGUILayout.BeginScrollView(_scroll);
+            EditorGUILayout.TextArea(_report, GUILayout.ExpandHeight(true));
+            EditorGUILayout.EndScrollView();
+        }
+
+        void Run()
+        {
+            var sb = new StringBuilder();
+            int passed = 0, total = 0;
+
+            void Check(string name, bool ok, string detail)
+            {
+                total++;
+                if (ok) passed++;
+                sb.Append(ok ? "  PASS  " : "  FAIL  ").Append(name);
+                if (!string.IsNullOrEmpty(detail)) sb.Append("   (").Append(detail).Append(')');
+                sb.Append('\n');
+            }
+
+            // ── 1. A balanced reef stays balanced ────────────────────────────
+            sb.Append("1. A balanced reef stays balanced over ").Append(_days).Append(" days\n");
+            var settings = new EcosystemSettings { enabled = true };
+            settings.Clamp();
+
+            var sim = new EcosystemSimulation(settings, 12345);
+            float startProducers = sim.GrazeableProducerBiomass();
+            Run(sim, _days);
+
+            var extinct = new StringBuilder();
+            bool allAlive = true;
+            for (int i = 0; i < SpeciesLibrary.Count; i++)
+            {
+                var def = SpeciesLibrary.Get(i);
+                if (def.IsProducer) continue;
+                if (sim.pools[i].count <= 0f)
+                {
+                    allAlive = false;
+                    if (extinct.Length > 0) extinct.Append(", ");
+                    extinct.Append(def.commonName);
+                }
+            }
+            Check("no species goes extinct", allAlive, extinct.ToString());
+
+            float drift = Mathf.Abs(sim.GrazeableProducerBiomass() - startProducers) / Mathf.Max(1f, startProducers);
+            Check("producers within 40% of their start", drift < 0.40f, $"drift {drift * 100f:0.0}%");
+            sb.Append(Snapshot(sim)).Append('\n');
+
+            // ── 2. Removing the tiger shark ──────────────────────────────────
+            sb.Append("2. Remove the tiger shark: urchins climb, algae fall\n");
+            sim = new EcosystemSimulation(settings, 12345);
+            Run(sim, 60);
+            float urchinBefore = sim.pools[SpeciesLibrary.Urchin].count;
+            float algaeBefore = sim.pools[SpeciesLibrary.Halimeda].biomass + sim.pools[SpeciesLibrary.Padina].biomass;
+            sim.SetPresent(SpeciesLibrary.TigerShark, false);
+
+            float peakUrchin = 0f, lowAlgae = float.MaxValue, peakOctopus = 0f;
+            for (int d = 0; d < 300; d++)
+            {
+                sim.Tick();
+                peakUrchin = Mathf.Max(peakUrchin, sim.pools[SpeciesLibrary.Urchin].count);
+                peakOctopus = Mathf.Max(peakOctopus, sim.pools[SpeciesLibrary.Octopus].count);
+                lowAlgae = Mathf.Min(lowAlgae,
+                    sim.pools[SpeciesLibrary.Halimeda].biomass + sim.pools[SpeciesLibrary.Padina].biomass);
+            }
+            Check("urchins climb", peakUrchin > urchinBefore * 1.5f,
+                  $"{urchinBefore:0.0} -> peak {peakUrchin:0.0}");
+            Check("algae fall", lowAlgae < algaeBefore * 0.85f,
+                  $"{algaeBefore:0.0} -> low {lowAlgae:0.0}");
+            Check("mesopredator release", peakOctopus > sim.pools[SpeciesLibrary.Octopus].count
+                  || peakOctopus > 5f, $"octopus peak {peakOctopus:0.00}");
+            sb.Append('\n');
+
+            // ── 3. A deliberately broken reef collapses in stages ────────────
+            sb.Append("3. A broken reef (no shark, no parrotfish) passes through the collapse stages\n");
+            var broken = new EcosystemSettings { enabled = true };
+            broken.Clamp();
+            broken.present[SpeciesLibrary.TigerShark] = false;
+            broken.present[SpeciesLibrary.Parrotfish] = false;
+
+            sim = new EcosystemSimulation(broken, 12345);
+            var health = new EcosystemHealth();
+            health.Reset(sim);
+
+            float algaeStart = sim.GrazeableProducerBiomass();
+            float peak = 0f, trough = float.MaxValue;
+            int barrenDay = -1;
+            var reached = new bool[6];
+
+            for (int d = 1; d <= 600; d++)
+            {
+                sim.Tick();
+                health.Evaluate(sim);
+                reached[(int)health.stage] = true;
+
+                float u = sim.pools[SpeciesLibrary.Urchin].count;
+                if (u > peak) { peak = u; trough = float.MaxValue; }
+                else trough = Mathf.Min(trough, u);
+
+                if (barrenDay < 0 && sim.GrazeableProducerBiomass() < algaeStart * 0.12f) barrenDay = d;
+            }
+
+            Check("urchins overshoot", peak > 60f, $"peak {peak:0.0}");
+            Check("then crash back", trough < peak * 0.6f, $"peak {peak:0.0} -> trough {trough:0.0}");
+            Check("reaches barren", barrenDay > 0, barrenDay > 0 ? $"day {barrenDay}" : "never");
+            Check("collapse is staged, not instant", barrenDay < 0 || barrenDay > 100, $"day {barrenDay}");
+
+            sb.Append("  stages seen: ");
+            for (int i = 1; i < reached.Length; i++)
+                if (reached[i]) sb.Append((CollapseStage)i).Append(' ');
+            sb.Append("\n\n");
+
+            // ── 4. Water conditions ──────────────────────────────────────────
+            sb.Append("4. Warming and acidification act on the calcifiers\n");
+            float warmCoral = CoralAfter(300, 30f, 8.1f);
+            float baseCoral = CoralAfter(300, 24f, 8.1f);
+            float acidCoral = CoralAfter(300, 24f, 7.7f);
+            Check("coral does worse in warm water", warmCoral < baseCoral * 0.80f,
+                  $"30C {warmCoral:0.0} vs 24C {baseCoral:0.0}");
+            Check("coral does worse in acidified water", acidCoral < baseCoral * 0.85f,
+                  $"pH7.7 {acidCoral:0.0} vs pH8.1 {baseCoral:0.0}");
+            sb.Append('\n');
+
+            // ── 5. Budgets ───────────────────────────────────────────────────
+            int stateBytes = SpeciesLibrary.Count * (sizeof(float) * 5 + sizeof(int) + sizeof(bool))
+                           + sizeof(float) * 2 + sizeof(int) * 2;
+            sb.Append("5. Budgets\n");
+            Check("simulation state under 10 KB", stateBytes < 10 * 1024, $"{stateBytes} bytes");
+            sb.Append('\n');
+
+            sb.Insert(0, $"{passed} of {total} checks passed.\n\n");
+            _report = sb.ToString();
+            Debug.Log("[LivingReef] Balance report:\n" + _report);
+        }
+
+        static float CoralAfter(int days, float temperature, float ph)
+        {
+            var settings = new EcosystemSettings { enabled = true, temperatureC = temperature, acidityPh = ph };
+            settings.Clamp();
+            var sim = new EcosystemSimulation(settings, 12345);
+            Run(sim, days);
+            return sim.pools[SpeciesLibrary.Coral].biomass;
+        }
+
+        static void Run(EcosystemSimulation sim, int days)
+        {
+            for (int i = 0; i < days; i++) sim.Tick();
+        }
+
+        static string Snapshot(EcosystemSimulation sim)
+        {
+            var sb = new StringBuilder("  final: ");
+            for (int i = 0; i < SpeciesLibrary.Count; i++)
+            {
+                var def = SpeciesLibrary.Get(i);
+                sb.Append(def.id).Append('=')
+                  .Append(sim.DisplayAmount(i).ToString("0.#"))
+                  .Append(i < SpeciesLibrary.Count - 1 ? "  " : "");
+            }
+            sb.Append("\n  detritus=").Append(sim.detritus.ToString("0.#"));
+            return sb.ToString();
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Editor/EcosystemBalanceWindow.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Editor/EcosystemBalanceWindow.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 91c18db1fb4beef44acbddf77da349d6

--- a/Assets/Scripts/LivingEcosystem/Editor/LivingReefPreviewScene.cs
+++ b/Assets/Scripts/LivingEcosystem/Editor/LivingReefPreviewScene.cs
@@ -1,0 +1,67 @@
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem.EditorTools
+{
+    // Builds a throwaway scene for looking at the reef, so testing needs no AR
+    // device, no plane detection and no trip through the environment builder.
+    //
+    // The scene is created in memory and never written to disk, so nothing in the
+    // project changes. Close it without saving when you are done.
+    public static class LivingReefPreviewScene
+    {
+        [MenuItem("Tools/Living Ecosystem/Open Preview Scene")]
+        static void Open()
+        {
+            if (!EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo()) return;
+
+            var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+            scene.name = "Living Reef Preview";
+
+            // Camera, looking slightly down at where the reef will sit.
+            // Far enough back to see the whole 9 m patch, and high enough to look
+            // across it rather than stand in it.
+            var cameraGo = new GameObject("Preview Camera", typeof(Camera), typeof(AudioListener));
+            cameraGo.transform.position = new Vector3(0f, 4.5f, -14f);
+            cameraGo.transform.rotation = Quaternion.Euler(14f, 0f, 0f);
+            var camera = cameraGo.GetComponent<Camera>();
+            camera.clearFlags = CameraClearFlags.SolidColor;
+            // Shallow Cabo Verde water, so the models read against the right ground.
+            camera.backgroundColor = new Color(0.05f, 0.30f, 0.42f);
+            camera.tag = "MainCamera";
+            camera.farClipPlane = 200f;
+
+            // A key light, so the Simple Lit meshes actually show their form.
+            var lightGo = new GameObject("Sun", typeof(Light));
+            lightGo.transform.rotation = Quaternion.Euler(52f, -30f, 0f);
+            var light = lightGo.GetComponent<Light>();
+            light.type = LightType.Directional;
+            light.intensity = 1.15f;
+            light.color = new Color(0.85f, 0.95f, 1f);
+
+            // Seafloor, so the sessile species have something to sit on and the
+            // renderer's downward raycast finds ground.
+            var floor = GameObject.CreatePrimitive(PrimitiveType.Plane);
+            floor.name = "Seafloor";
+            floor.transform.localScale = new Vector3(4f, 1f, 4f);
+            var floorRenderer = floor.GetComponent<Renderer>();
+            var sand = new Material(Shader.Find("Universal Render Pipeline/Simple Lit")
+                                 ?? Shader.Find("Diffuse"));
+            // Pale volcanic carbonate sand.
+            if (sand.HasProperty("_BaseColor")) sand.SetColor("_BaseColor", new Color(0.78f, 0.73f, 0.62f));
+            if (sand.HasProperty("_Color")) sand.SetColor("_Color", new Color(0.78f, 0.73f, 0.62f));
+            floorRenderer.sharedMaterial = sand;
+
+            // The harness itself.
+            var reef = new GameObject("Living Reef Preview", typeof(LivingReefPreview));
+            Selection.activeGameObject = reef;
+
+            EditorGUIUtility.PingObject(reef);
+            Debug.Log("[LivingReef] Preview scene ready. Press Play, then open the 'Reef' tab " +
+                      "on the right-hand edge of the Game view. " +
+                      "Untick 'Tiger Shark' on the Living Reef Preview object before pressing Play " +
+                      "to watch the trophic cascade, or use its right-click menu while playing.");
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Editor/LivingReefPreviewScene.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Editor/LivingReefPreviewScene.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 72a0e5b0dfb8c5341b429a15788e3261

--- a/Assets/Scripts/LivingEcosystem/Editor/ReefMemoryWindow.cs
+++ b/Assets/Scripts/LivingEcosystem/Editor/ReefMemoryWindow.cs
@@ -1,0 +1,286 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using CreateEnv.Ecosystem.Genetics;
+using CreateEnv.Ecosystem.Memory;
+using UnityEditor;
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem.EditorTools
+{
+    // A bench for the parts of Milestone 3 that are otherwise only reachable on a
+    // phone after a day of waiting.
+    //
+    // Two of the three things added in this milestone are hard to test honestly. The
+    // Welcome Back card needs an absence measured in hours; the report needs a reef
+    // with a long history and a family tree several generations deep. Both are here
+    // as buttons: backdate a save, or run a reef forward and produce the PDF.
+    //
+    // Editor-only, and it touches nothing at runtime.
+    public class ReefMemoryWindow : EditorWindow
+    {
+        Vector2 _scroll;
+        string _status = "";
+        int _simulatedDays = 400;
+        int _seed = 4242;
+        float _temperature = 27.5f;
+        int _hoursAway = 6;
+
+        [MenuItem("Tools/Living Ecosystem/Saved Reefs and Reports")]
+        public static void Open()
+        {
+            var window = GetWindow<ReefMemoryWindow>();
+            window.titleContent = new GUIContent("Reef Memory");
+            window.minSize = new Vector2(460f, 420f);
+        }
+
+        void OnGUI()
+        {
+            _scroll = EditorGUILayout.BeginScrollView(_scroll);
+
+            EditorGUILayout.LabelField("Saved reefs", EditorStyles.boldLabel);
+            EditorGUILayout.LabelField(ReefSaveFile.Folder, EditorStyles.miniLabel);
+            EditorGUILayout.Space(4f);
+
+            DrawSaves();
+
+            EditorGUILayout.Space(14f);
+            EditorGUILayout.LabelField("Sample report", EditorStyles.boldLabel);
+            EditorGUILayout.HelpBox(
+                "Runs a reef headlessly and writes the PDF it would produce. No scene, no " +
+                "device and no AR session required — this is the fastest way to see what " +
+                "the report actually looks like.", MessageType.None);
+
+            _simulatedDays = EditorGUILayout.IntSlider("Days to simulate", _simulatedDays, 1, 1200);
+            _seed = EditorGUILayout.IntField("Seed", _seed);
+            _temperature = EditorGUILayout.Slider("Temperature (°C)", _temperature, 20f, 32f);
+
+            if (GUILayout.Button("Build a sample report", GUILayout.Height(26f)))
+                BuildSample();
+
+            EditorGUILayout.Space(14f);
+            EditorGUILayout.LabelField("From the running game", EditorStyles.boldLabel);
+
+            using (new EditorGUI.DisabledScope(!Application.isPlaying))
+            {
+                if (GUILayout.Button("Report on the reef that is playing now", GUILayout.Height(26f)))
+                    ReportOnLiveReef();
+
+                if (GUILayout.Button("Save the reef that is playing now"))
+                    SaveLiveReef();
+            }
+
+            if (!string.IsNullOrEmpty(_status))
+            {
+                EditorGUILayout.Space(10f);
+                EditorGUILayout.HelpBox(_status, MessageType.Info);
+            }
+
+            EditorGUILayout.EndScrollView();
+        }
+
+        // ── Saved reefs ──────────────────────────────────────────────────────
+
+        void DrawSaves()
+        {
+            if (!Directory.Exists(ReefSaveFile.Folder))
+            {
+                EditorGUILayout.HelpBox("No reef has been saved yet. Play FreeExploreEndless with " +
+                                        "an environment that has the ecosystem switched on, then " +
+                                        "leave play mode.", MessageType.None);
+                return;
+            }
+
+            var files = Directory.GetFiles(ReefSaveFile.Folder, "*.json");
+            if (files.Length == 0)
+            {
+                EditorGUILayout.HelpBox("The folder exists but holds no saves.", MessageType.None);
+                return;
+            }
+
+            EditorGUILayout.LabelField("An hour away is a day in the ocean, up to " +
+                                       TimeAway.MaximumDays + " days.", EditorStyles.miniLabel);
+            EditorGUILayout.Space(2f);
+
+            foreach (var file in files)
+            {
+                string id = Path.GetFileNameWithoutExtension(file);
+                var save = ReefSaveFile.Read(id);
+
+                using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
+                {
+                    if (save == null)
+                    {
+                        EditorGUILayout.LabelField(id, "unreadable, or written by another build");
+                        if (GUILayout.Button("Delete")) Delete(id);
+                        continue;
+                    }
+
+                    double hours = save.HoursAway(DateTime.UtcNow);
+                    var away = TimeAway.Measure(hours);
+
+                    EditorGUILayout.LabelField(id, EditorStyles.boldLabel);
+                    EditorGUILayout.LabelField(
+                        $"day {save.day}   ·   {new FileInfo(file).Length} bytes of " +
+                        $"{ReefSaveFile.BudgetBytes}   ·   generation {save.highestGeneration}");
+                    EditorGUILayout.LabelField(
+                        $"closed {hours:0.0} h ago, which would run {away.daysToRun} days" +
+                        (away.wasCapped ? " (capped)" : "") +
+                        (away.worthReporting ? "" : " — too short to show the card"),
+                        EditorStyles.miniLabel);
+
+                    using (new EditorGUILayout.HorizontalScope())
+                    {
+                        _hoursAway = EditorGUILayout.IntField("Pretend hours away", _hoursAway);
+                        if (GUILayout.Button("Backdate", GUILayout.Width(90f)))
+                            Backdate(id, save, _hoursAway);
+                    }
+
+                    using (new EditorGUILayout.HorizontalScope())
+                    {
+                        if (GUILayout.Button("Show the file"))
+                            EditorUtility.RevealInFinder(file);
+                        if (GUILayout.Button("Delete"))
+                            Delete(id);
+                    }
+                }
+            }
+        }
+
+        // Moves the save's clock backwards so the next play session behaves as though
+        // the learner had been away that long. The alternative is to wait.
+        void Backdate(string id, ReefSave save, int hours)
+        {
+            save.closedAtUtc = DateTime.UtcNow.AddHours(-Math.Max(0, hours)).ToString("O");
+            ReefSaveFile.Write(save);
+            _status = $"'{id}' now reads as {hours} hours old. Enter play mode to see the " +
+                      "Welcome Back card.";
+        }
+
+        void Delete(string id)
+        {
+            if (!EditorUtility.DisplayDialog("Delete this reef?",
+                    $"'{id}' will start again from scratch the next time it is played.",
+                    "Delete", "Keep")) return;
+
+            ReefSaveFile.Delete(id);
+            _status = $"Deleted '{id}'.";
+        }
+
+        // ── Sample report ────────────────────────────────────────────────────
+
+        void BuildSample()
+        {
+            try
+            {
+                var source = RunAReef(_simulatedDays, _seed, _temperature);
+                WriteAndReveal(EcosystemReport.Build(source),
+                               "sample-reef-report.pdf",
+                               $"Simulated {_simulatedDays} days at {_temperature:0.#} °C.");
+            }
+            catch (Exception e)
+            {
+                _status = "The sample could not be built: " + e;
+                Debug.LogException(e);
+            }
+        }
+
+        // The same loop LivingReefController runs, minus everything to do with drawing.
+        static EcosystemReport.Source RunAReef(int days, int seed, float temperature)
+        {
+            var settings = new EcosystemSettings
+            {
+                enabled = true,
+                temperatureC = temperature,
+                predictionIndex = 0,
+            };
+            settings.Clamp();
+
+            var sim = new EcosystemSimulation(settings, seed);
+            sim.temperatureC = temperature;
+            sim.agentManaged[SpeciesLibrary.Octopus] = true;
+
+            var health = new EcosystemHealth();
+            health.Reset(sim);
+
+            var reasons = new ReasonEngine();
+            reasons.Reset();
+
+            var octopuses = new OctopusPopulation();
+            octopuses.Found(5, seed);
+
+            var chronicle = new ReefChronicle();
+            octopuses.journal = chronicle.journal;
+            chronicle.Begin(sim, health, octopuses);
+
+            for (int d = 0; d < days; d++)
+            {
+                sim.Tick();
+                octopuses.Tick(sim, SpeciesLibrary.Octopus);
+                health.Evaluate(sim);
+                reasons.Observe(sim);
+                reasons.Evaluate(sim, health);
+                chronicle.Observe(sim, health, octopuses);
+            }
+
+            return new EcosystemReport.Source
+            {
+                environmentName = "Sample Reef",
+                sim = sim,
+                health = health,
+                settings = settings,
+                octopuses = octopuses,
+                chronicle = chronicle,
+                reasons = reasons.Active,
+            };
+        }
+
+        // ── The live reef ────────────────────────────────────────────────────
+
+        void ReportOnLiveReef()
+        {
+            var reef = FindObjectOfType<LivingReefController>();
+            if (reef == null)
+            {
+                _status = "No Living Reef is running. It installs itself only in " +
+                          LivingReefBootstrap.TargetScene + ", and only when the chosen " +
+                          "environment has the ecosystem switched on.";
+                return;
+            }
+
+            var profile = EnvironmentSession.Selected;
+            string name = profile != null ? profile.displayName : "My Reef";
+            var result = ReportShare.ShareReport(reef, name);
+
+            _status = result.ok
+                ? "Written to " + result.path
+                : "Could not write the report: " + result.failure;
+        }
+
+        void SaveLiveReef()
+        {
+            var reef = FindObjectOfType<LivingReefController>();
+            if (reef == null) { _status = "No Living Reef is running."; return; }
+
+            reef.Save();
+            _status = "Saved. It will appear in the list above.";
+        }
+
+        void WriteAndReveal(byte[] pdf, string fileName, string note)
+        {
+            string folder = Path.Combine(Application.persistentDataPath, "reports");
+            Directory.CreateDirectory(folder);
+            string path = Path.Combine(folder, fileName);
+
+            File.WriteAllBytes(path, pdf);
+            EditorUtility.RevealInFinder(path);
+
+            _status = note + $"\n{pdf.Length:N0} bytes written to\n{path}";
+        }
+
+        // FindObjectOfType is deprecated in Unity 6, but the replacement is only worth
+        // reaching for in code that runs every frame. This runs when a button is clicked.
+        static T FindObjectOfType<T>() where T : UnityEngine.Object =>
+            UnityEngine.Object.FindFirstObjectByType<T>();
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Editor/ReefMemoryWindow.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Editor/ReefMemoryWindow.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dcfac8184fd44564eabf4afdf1b931a9

--- a/Assets/Scripts/LivingEcosystem/Editor/SpeciesLibraryAssetCreator.cs
+++ b/Assets/Scripts/LivingEcosystem/Editor/SpeciesLibraryAssetCreator.cs
@@ -1,0 +1,61 @@
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem.EditorTools
+{
+    // Writes a SpeciesLibrary asset pre-filled with the built-in roster, into a
+    // Resources folder where the simulation will find it.
+    //
+    // After this, every rate is an inspector field: balancing needs no rebuild, and
+    // no code change, which is what the milestone document asks for. Deleting the
+    // asset falls straight back to the built-in roster.
+    public static class SpeciesLibraryAssetCreator
+    {
+        const string Folder = "Assets/Resources";
+        const string AssetPath = Folder + "/SpeciesLibrary.asset";
+
+        [MenuItem("Tools/Living Ecosystem/Create Species Library Asset")]
+        static void Create()
+        {
+            if (File.Exists(AssetPath))
+            {
+                bool replace = EditorUtility.DisplayDialog(
+                    "Species Library already exists",
+                    "A SpeciesLibrary asset is already present. Replacing it will discard any " +
+                    "balancing you have done in it.\n\nReplace it?",
+                    "Replace", "Cancel");
+                if (!replace) return;
+            }
+
+            if (!Directory.Exists(Folder)) Directory.CreateDirectory(Folder);
+
+            var asset = ScriptableObject.CreateInstance<SpeciesLibraryAsset>();
+            // Stamped so a later build can tell this was written before any fields it
+            // now expects, and ignore it loudly rather than override the code with zeros.
+            asset.rosterVersion = SpeciesLibrary.RosterVersion;
+
+            // Clone the built-ins so the asset owns its own copies and editing it
+            // cannot mutate the code defaults for the rest of the session.
+            var source = SpeciesLibrary.All;
+            asset.species = new SpeciesDefinition[source.Length];
+            for (int i = 0; i < source.Length; i++) asset.species[i] = source[i].Clone();
+
+            var web = SpeciesLibrary.Web;
+            asset.web = new FoodLink[web.Length];
+            for (int i = 0; i < web.Length; i++)
+                asset.web[i] = new FoodLink(web[i].predator, web[i].prey,
+                                            web[i].preference, web[i].halfSaturation);
+
+            AssetDatabase.CreateAsset(asset, AssetPath);
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+            SpeciesLibrary.Invalidate();
+
+            Selection.activeObject = asset;
+            EditorGUIUtility.PingObject(asset);
+            Debug.Log($"[LivingReef] Created {AssetPath}. Every rate is now editable without a rebuild. " +
+                      "Re-run Tools > Living Ecosystem > Balance Report after changing anything.");
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Editor/SpeciesLibraryAssetCreator.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Editor/SpeciesLibraryAssetCreator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6be9dd5db4fce1942a3c45b915e1dbf5

--- a/Assets/Scripts/LivingEcosystem/Genetics.meta
+++ b/Assets/Scripts/LivingEcosystem/Genetics.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 18c0788e67efb49448feddba5cb43d8c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/LivingEcosystem/Genetics/Genome.cs
+++ b/Assets/Scripts/LivingEcosystem/Genetics/Genome.cs
@@ -1,0 +1,309 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem.Genetics
+{
+    public enum GeneId
+    {
+        Camouflage    = 0,   // dominant / recessive
+        BodySize      = 1,   // additive, three levels
+        HeatTolerance = 2,   // additive, three levels
+    }
+
+    // Three genes, two copies of each (Design Document 4.1).
+    //
+    // One byte per gene, two alleles in the low two bits: a set bit is the uppercase
+    // variant. Three bytes an animal, which is what makes keeping a pedigree of dead
+    // ancestors cost almost nothing.
+    //
+    // The three genes are deliberately not all the same kind of inheritance, because
+    // that is the point of the lesson (Literature 3.2 and 3.3):
+    //
+    //   A  camouflage     dominant/recessive — one strong copy is enough, and a weak
+    //                     copy can hide for generations and reappear
+    //   B  body size      additive — each copy adds a little, giving a range rather
+    //                     than two categories
+    //   C  heat tolerance additive — the same, and the main thing selection acts on
+    [Serializable]
+    public struct Genome
+    {
+        public byte camouflage;
+        public byte bodySize;
+        public byte heatTolerance;
+
+        public const int GeneCount = 3;
+
+        // The letter used when writing a genotype out, e.g. "AaBBcc".
+        public static char LetterOf(GeneId gene) => gene switch
+        {
+            GeneId.Camouflage    => 'A',
+            GeneId.BodySize      => 'B',
+            _                    => 'C',
+        };
+
+        public static string NameOf(GeneId gene) => gene switch
+        {
+            GeneId.Camouflage    => "Camouflage",
+            GeneId.BodySize      => "Body size",
+            _                    => "Heat tolerance",
+        };
+
+        public static string DescriptionOf(GeneId gene) => gene switch
+        {
+            GeneId.Camouflage =>
+                "Strong camouflage is dominant: one strong copy is enough. A weak copy is not " +
+                "lost when it is hidden — it can be passed on and reappear in a later generation, " +
+                "which is why traits can skip generations.",
+            GeneId.BodySize =>
+                "Additive: each copy adds a little, so sizes spread across a range instead of " +
+                "falling into two groups. A bigger octopus hunts better but needs more food.",
+            _ =>
+                "Additive, and the main thing selection acts on here. In warm water an octopus " +
+                "with poor heat tolerance spends more energy staying alive, so it more often " +
+                "dies before it breeds.",
+        };
+
+        public byte Raw(GeneId gene) => gene switch
+        {
+            GeneId.Camouflage    => camouflage,
+            GeneId.BodySize      => bodySize,
+            _                    => heatTolerance,
+        };
+
+        public void SetRaw(GeneId gene, byte value)
+        {
+            switch (gene)
+            {
+                case GeneId.Camouflage:    camouflage = value; break;
+                case GeneId.BodySize:      bodySize = value; break;
+                default:                   heatTolerance = value; break;
+            }
+        }
+
+        // One allele: true is the uppercase variant. Copy 0 came from the mother,
+        // copy 1 from the father.
+        public bool Allele(GeneId gene, int copy) => (Raw(gene) & (1 << copy)) != 0;
+
+        // How many uppercase copies this animal carries: 0, 1 or 2.
+        public int CopiesOf(GeneId gene)
+        {
+            byte raw = Raw(gene);
+            return (raw & 1) + ((raw >> 1) & 1);
+        }
+
+        public bool IsHeterozygous(GeneId gene) => CopiesOf(gene) == 1;
+
+        // "AA", "Aa" or "aa" — always written with the uppercase copy first, so the
+        // same genotype always reads the same way.
+        public string Notation(GeneId gene)
+        {
+            char upper = LetterOf(gene);
+            char lower = char.ToLowerInvariant(upper);
+            return CopiesOf(gene) switch
+            {
+                2 => $"{upper}{upper}",
+                1 => $"{upper}{lower}",
+                _ => $"{lower}{lower}",
+            };
+        }
+
+        // The whole genotype, e.g. "AaBBcc".
+        public string Notation() =>
+            Notation(GeneId.Camouflage) + Notation(GeneId.BodySize) + Notation(GeneId.HeatTolerance);
+
+        // ── Building genomes ─────────────────────────────────────────────────
+
+        public static Genome FromCopies(int camouflageCopies, int bodyCopies, int heatCopies)
+        {
+            var g = new Genome();
+            g.camouflage    = PackCopies(camouflageCopies);
+            g.bodySize      = PackCopies(bodyCopies);
+            g.heatTolerance = PackCopies(heatCopies);
+            return g;
+        }
+
+        static byte PackCopies(int copies) => copies switch
+        {
+            >= 2 => 0b11,
+            1    => 0b01,
+            _    => 0b00,
+        };
+
+        public static Genome Random(System.Random rng)
+        {
+            var g = new Genome();
+            foreach (GeneId gene in Enum.GetValues(typeof(GeneId)))
+            {
+                byte raw = 0;
+                if (rng.NextDouble() < 0.5) raw |= 1;
+                if (rng.NextDouble() < 0.5) raw |= 2;
+                g.SetRaw(gene, raw);
+            }
+            return g;
+        }
+
+        // Each parent passes one randomly chosen copy of each gene (Literature 3.4).
+        // That single rule is what the Punnett grid predicts, and what makes a small
+        // brood so often fail to match the prediction.
+        public static Genome Inherit(Genome mother, Genome father, System.Random rng, float mutationRate)
+        {
+            var child = new Genome();
+
+            foreach (GeneId gene in Enum.GetValues(typeof(GeneId)))
+            {
+                bool fromMother = mother.Allele(gene, rng.NextDouble() < 0.5 ? 0 : 1);
+                bool fromFather = father.Allele(gene, rng.NextDouble() < 0.5 ? 0 : 1);
+
+                // Mutation is the only source of genuinely new variation; everything
+                // else just reshuffles what is already there (Literature 3.5). The
+                // real rate is far too low to see in a session, so it is raised, and
+                // the interface says so.
+                if (rng.NextDouble() < mutationRate) fromMother = !fromMother;
+                if (rng.NextDouble() < mutationRate) fromFather = !fromFather;
+
+                byte raw = 0;
+                if (fromMother) raw |= 1;
+                if (fromFather) raw |= 2;
+                child.SetRaw(gene, raw);
+            }
+            return child;
+        }
+
+        public bool Equals(Genome other) =>
+            camouflage == other.camouflage &&
+            bodySize == other.bodySize &&
+            heatTolerance == other.heatTolerance;
+    }
+
+    // The inheritance grid, named after Reginald Punnett (Literature 3.4).
+    //
+    // Lives beside Genome deliberately: it predicts what Genome.Inherit will do,
+    // so keeping the two in one file makes it obvious that they have to agree.
+    // The harness checks that they do, against forty thousand sampled crosses per
+    // genotype pair.
+    //
+    // Because each parent passes one randomly chosen copy of each gene, the possible
+    // combinations lay out in a two-by-two grid and the expected ratios read straight
+    // off it. This computes exactly that, from the same rule Genome.Inherit uses, so
+    // the prediction the learner sees and the maths the simulation runs cannot drift
+    // apart. The harness checks that they agree.
+    //
+    // The lesson hidden inside the tool: a grid predicts ratios over many offspring.
+    // A brood of three will frequently not match, and that is not a bug — it is how
+    // chance works with small numbers.
+    public static class PunnettPrediction
+    {
+        public struct Cell
+        {
+            public bool fromMother;   // the allele this parent contributed
+            public bool fromFather;
+            public int copies;        // 0, 1 or 2 uppercase copies in the offspring
+            public string notation;   // "AA", "Aa", "aa"
+        }
+
+        public struct Outcome
+        {
+            public int copies;
+            public string notation;
+            public float probability;   // 0..1
+            public string phenotype;    // what that genotype actually looks like
+        }
+
+        // The four cells of the grid, in reading order.
+        public static Cell[] Grid(Genome mother, Genome father, GeneId gene)
+        {
+            var cells = new Cell[4];
+            int i = 0;
+            for (int m = 0; m < 2; m++)
+            {
+                for (int f = 0; f < 2; f++)
+                {
+                    bool am = mother.Allele(gene, m);
+                    bool af = father.Allele(gene, f);
+                    int copies = (am ? 1 : 0) + (af ? 1 : 0);
+
+                    var g = new Genome();
+                    byte raw = 0;
+                    if (am) raw |= 1;
+                    if (af) raw |= 2;
+                    g.SetRaw(gene, raw);
+
+                    cells[i++] = new Cell
+                    {
+                        fromMother = am,
+                        fromFather = af,
+                        copies = copies,
+                        notation = g.Notation(gene),
+                    };
+                }
+            }
+            return cells;
+        }
+
+        // The distinct outcomes and how likely each is, most likely first.
+        public static List<Outcome> Outcomes(Genome mother, Genome father, GeneId gene)
+        {
+            var grid = Grid(mother, father, gene);
+            var counts = new Dictionary<int, int>();
+            foreach (var cell in grid)
+                counts[cell.copies] = counts.TryGetValue(cell.copies, out int n) ? n + 1 : 1;
+
+            var list = new List<Outcome>(3);
+            foreach (var pair in counts)
+            {
+                var g = Genome.FromCopies(
+                    gene == GeneId.Camouflage ? pair.Key : 0,
+                    gene == GeneId.BodySize ? pair.Key : 0,
+                    gene == GeneId.HeatTolerance ? pair.Key : 0);
+
+                list.Add(new Outcome
+                {
+                    copies = pair.Key,
+                    notation = g.Notation(gene),
+                    probability = pair.Value / 4f,
+                    phenotype = PhenotypeWord(gene, pair.Key),
+                });
+            }
+
+            list.Sort((a, b) => b.probability.CompareTo(a.probability));
+            return list;
+        }
+
+        // What a given number of uppercase copies produces, in plain words. Mirrors
+        // OctopusTraits: camouflage is dominant so one copy is already strong, while
+        // the additive genes step through three levels.
+        public static string PhenotypeWord(GeneId gene, int copies)
+        {
+            if (gene == GeneId.Camouflage)
+                return copies >= 1 ? "Strong camouflage" : "Weak camouflage";
+
+            if (gene == GeneId.BodySize)
+                return copies switch { 2 => "Large", 1 => "Medium", _ => "Small" };
+
+            return copies switch { 2 => "High heat tolerance", 1 => "Moderate heat tolerance", _ => "Low heat tolerance" };
+        }
+
+        // A ratio written the way a textbook would: "3 : 1", "1 : 2 : 1", "all".
+        public static string RatioText(Genome mother, Genome father, GeneId gene)
+        {
+            var grid = Grid(mother, father, gene);
+            var byCopies = new int[3];
+            foreach (var cell in grid) byCopies[cell.copies]++;
+
+            var parts = new List<string>(3);
+            for (int copies = 2; copies >= 0; copies--)
+                if (byCopies[copies] > 0)
+                    parts.Add($"{byCopies[copies]}");
+
+            if (parts.Count == 1) return "all the same";
+            return string.Join(" : ", parts);
+        }
+
+        // The line the breeding tool prints under the grid, so the learner is told in
+        // advance that a small brood often will not match.
+        public const string SmallBroodCaveat =
+            "A grid predicts ratios over many offspring. A brood of two to four will often not " +
+            "match it — that is not a mistake, it is how chance works with small numbers.";
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Genetics/Genome.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Genetics/Genome.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0948bd25ac47f244387662068af0de27

--- a/Assets/Scripts/LivingEcosystem/Genetics/OctopusAgent.cs
+++ b/Assets/Scripts/LivingEcosystem/Genetics/OctopusAgent.cs
@@ -1,0 +1,156 @@
+using System;
+
+namespace CreateEnv.Ecosystem.Genetics
+{
+    public enum Sex { Female = 0, Male = 1 }
+
+    // What an octopus is doing. The design document's state machine
+    // (rest, hunt, flee, mate, brood, die), kept exactly that small.
+    public enum OctopusState
+    {
+        Resting  = 0,
+        Hunting  = 1,
+        Fleeing  = 2,
+        Mating   = 3,
+        Brooding = 4,
+        Dead     = 5,
+    }
+
+    public enum CauseOfDeath
+    {
+        StillAlive = 0,
+        Starved    = 1,
+        Predated   = 2,
+        AfterBreeding = 3,   // semelparity: it bred, and that is what kills it
+        OldAge     = 4,
+    }
+
+    // One octopus. Individuals rather than a number pool, because these are the
+    // animals the learner taps, inspects and breeds (Design Document 3.1).
+    [Serializable]
+    public class OctopusAgent
+    {
+        public int id;
+        public int nameIndex;
+        public string name;
+        public Genome genome;
+        public Sex sex;
+
+        public int generation;
+        public int motherId = -1;
+        public int fatherId = -1;
+
+        public float ageDays;
+        public float energy = 1f;        // 0 starving .. 2 well fed
+        public OctopusState state = OctopusState.Resting;
+
+        // Individual variation on top of the genotype, drawn once at birth.
+        public float noiseSeed;
+
+        // Brooding
+        public float broodDaysRemaining;
+        public int   pendingYoung;
+        public int   mateId = -1;
+
+        // The female stores the sperm packets she was given, and can hold them for
+        // days or months before using them (Literature 4.8). Keeping the father's
+        // genome here is what lets him die — as he always does — well before the eggs
+        // hatch, without the brood losing its father.
+        public Genome storedMate;
+        public int    storedMateId = -1;
+
+        // Days left before a mated male dies. He has been declining since shortly
+        // after mating and is usually dead well before the eggs hatch (Literature
+        // 4.8) — but he does not drop on the spot, and in a population this small
+        // that difference is the difference between a lineage continuing and dying
+        // out for want of a mate.
+        public float declineDaysRemaining;
+        public bool HasMated => declineDaysRemaining > 0f;
+
+        // Share of the day's catch this animal competed for, recomputed each tick.
+        [NonSerialized] public float huntingShare;
+
+        public CauseOfDeath causeOfDeath = CauseOfDeath.StillAlive;
+        public int diedOnDay = -1;
+        public int bornOnDay;
+
+        [NonSerialized] public OctopusTraits traits;
+
+        public bool IsAlive => state != OctopusState.Dead;
+
+        // Brooding is a condition, not a pose. Deriving it from `state` meant any
+        // transient state change clobbered it — an escape from the shark set
+        // Fleeing, the female silently stopped brooding, and her eggs never hatched.
+        // The countdown is the authority; `state` is only what the interface says
+        // she is doing.
+        public bool IsBrooding => broodDaysRemaining > 0f;
+
+        public void RefreshTraits() => traits = OctopusTraits.From(genome, noiseSeed);
+
+        public bool IsMature(float maturityDays) => ageDays >= maturityDays;
+
+        // Body mass scales with the size gene, so a large octopus really is a larger
+        // share of the pool's biomass — and therefore a bigger meal for the shark.
+        public float Mass(float baseUnitMass) => baseUnitMass * traits.bodySize;
+
+        public string SexWord => sex == Sex.Female ? "Female" : "Male";
+
+        public string StateWord => state switch
+        {
+            OctopusState.Resting  => "Resting in its den",
+            OctopusState.Hunting  => "Hunting",
+            OctopusState.Fleeing  => "Hiding from the shark",
+            OctopusState.Mating   => "Mating",
+            OctopusState.Brooding => "Brooding her eggs, not eating",
+            _                     => "Dead",
+        };
+
+        public static string CauseWord(CauseOfDeath cause) => cause switch
+        {
+            CauseOfDeath.Starved       => "starved",
+            CauseOfDeath.Predated      => "taken by the tiger shark",
+            CauseOfDeath.AfterBreeding => "died after breeding",
+            CauseOfDeath.OldAge        => "died of old age",
+            _                          => "alive",
+        };
+    }
+
+    // A dead octopus, kept so the family tree survives it.
+    //
+    // Roughly twenty bytes: name index, genes, generation, parents and cause of
+    // death. Dead animals are kept as records, not as agents, which is what keeps an
+    // eight-generation pedigree well under a kilobyte (Design Document 4.4).
+    [Serializable]
+    public struct AncestorRecord
+    {
+        public int id;
+        public int nameIndex;
+        public Genome genome;
+        public byte generation;
+        public byte sexAndCause;   // low nibble: sex, high nibble: cause of death
+        public int motherId;
+        public int fatherId;
+        public short diedOnDay;
+        public short ageAtDeath;
+
+        public Sex Sex => (Sex)(sexAndCause & 0x0F);
+        public CauseOfDeath Cause => (CauseOfDeath)((sexAndCause >> 4) & 0x0F);
+        public string Name => OctopusNames.At(nameIndex);
+
+        public static AncestorRecord From(OctopusAgent a, int nameIndex)
+        {
+            return new AncestorRecord
+            {
+                id = a.id,
+                nameIndex = nameIndex,
+                genome = a.genome,
+                generation = (byte)Math.Min(255, a.generation),
+                sexAndCause = (byte)(((int)a.sex & 0x0F) | (((int)a.causeOfDeath & 0x0F) << 4)),
+                motherId = a.motherId,
+                fatherId = a.fatherId,
+                diedOnDay = (short)Math.Min(short.MaxValue, a.diedOnDay),
+                ageAtDeath = (short)Math.Min(short.MaxValue, (int)a.ageDays),
+            };
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Genetics/OctopusAgent.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Genetics/OctopusAgent.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2a18471926e452246b8de60f35fbc67f

--- a/Assets/Scripts/LivingEcosystem/Genetics/OctopusAgentView.cs
+++ b/Assets/Scripts/LivingEcosystem/Genetics/OctopusAgentView.cs
@@ -1,0 +1,101 @@
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem.Genetics
+{
+    // The visible half of one octopus.
+    //
+    // Body size and camouflage are read straight off the genome, so genetic
+    // differences are visible in AR rather than only in a panel: a large octopus is
+    // physically bigger, and a well-camouflaged one fades toward the colour of the
+    // sand it is sitting on while a poorly camouflaged one stays conspicuous. That
+    // second one is also the animal the shark is likelier to take, so what the
+    // learner can see and what the simulation acts on are the same thing.
+    //
+    // Per-individual colour goes through a MaterialPropertyBlock rather than a
+    // material of its own. Giving every octopus its own Material broke batching for
+    // the whole reef; a property block changes only what this renderer draws with.
+    public class OctopusAgentView : MonoBehaviour
+    {
+        public int agentId = -1;
+
+        Renderer _renderer;
+        MaterialPropertyBlock _block;
+        Color _baseTint;
+
+        float _shownCamouflage = -1f;
+        float _shownSize = -1f;
+        float _shownGlow = -1f;
+        bool _dirty;
+
+        // The colour a well-camouflaged octopus disappears into: pale Cabo Verde
+        // carbonate sand.
+        static readonly Color Seabed = new Color(0.74f, 0.70f, 0.60f);
+
+        public void Bind(Renderer targetRenderer, Color baseTint)
+        {
+            _renderer = targetRenderer;
+            _baseTint = baseTint;
+            _block = new MaterialPropertyBlock();
+        }
+
+        public void Apply(OctopusAgent agent, float baseScale)
+        {
+            if (agent == null || _renderer == null) return;
+            agentId = agent.id;
+
+            // Size: the additive gene, straight onto the model.
+            if (!Mathf.Approximately(_shownSize, agent.traits.bodySize))
+            {
+                _shownSize = agent.traits.bodySize;
+                transform.localScale = Vector3.one * (baseScale * agent.traits.bodySize);
+            }
+
+            // Camouflage: how far it has faded into the seabed. A brooding female is
+            // tucked into her den and reads as hidden whatever her genes say.
+            float shown = agent.traits.camouflage;
+            if (agent.IsBrooding) shown = Mathf.Min(1f, shown + 0.25f);
+
+            if (!Mathf.Approximately(_shownCamouflage, shown))
+            {
+                _shownCamouflage = shown;
+                _dirty = true;
+            }
+
+            if (_dirty) Flush();
+        }
+
+        // A soft light on an octopus the learner has singled out, or one that is
+        // brooding. Deliberately gentle: enough to follow her across the reef, not
+        // enough to look like a video game marker.
+        public void SetGlow(float amount)
+        {
+            amount = Mathf.Clamp01(amount);
+            if (Mathf.Abs(amount - _shownGlow) < 0.02f) return;
+            _shownGlow = amount;
+            _dirty = true;
+        }
+
+        // One write to the renderer covering colour and glow together, rather than
+        // one per property per frame.
+        void Flush()
+        {
+            _dirty = false;
+            if (_renderer == null || _block == null) return;
+
+            // Never all the way to the sand: the learner must still be able to find
+            // and tap it.
+            float camo = Mathf.Max(0f, _shownCamouflage);
+            var tint = Color.Lerp(_baseTint, Seabed, camo * 0.78f);
+
+            _renderer.GetPropertyBlock(_block);
+            _block.SetColor(SpeciesVisualLibrary.BaseColorId, tint);
+            _block.SetColor(SpeciesVisualLibrary.ColorId, tint);
+
+            float glow = Mathf.Max(0f, _shownGlow);
+            _block.SetColor(SpeciesVisualLibrary.EmissionId,
+                            new Color(0.42f, 0.86f, 0.72f) * (glow * 0.55f));
+
+            _renderer.SetPropertyBlock(_block);
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Genetics/OctopusAgentView.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Genetics/OctopusAgentView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d7dba607e8d2acb4697b1c77aa01890d

--- a/Assets/Scripts/LivingEcosystem/Genetics/OctopusNames.cs
+++ b/Assets/Scripts/LivingEcosystem/Genetics/OctopusNames.cs
@@ -1,0 +1,32 @@
+namespace CreateEnv.Ecosystem.Genetics
+{
+    // Short readable names, assigned at birth from a fixed word list.
+    //
+    // Names make lineage memorable in a way that identity numbers never do
+    // (Design Document 4.4). "Nova, Tide and their six descendants all carry their
+    // grandmother's camouflage variant" is a story; "individual 47" is not.
+    public static class OctopusNames
+    {
+        // Sea and light words, one or two syllables, easy to read at a glance and
+        // easy to tell apart from each other in a family tree.
+        static readonly string[] Words =
+        {
+            "Nova",  "Tide",  "Pebble", "Pearl", "Inky",  "Wisp",  "Ridge", "Drift",
+            "Kelp",  "Shell", "Reef",   "Onyx",  "Mist",  "Dune",  "Surf",  "Ember",
+            "Slate", "Fern",  "Gull",   "Cove",  "Marl",  "Spire", "Foam",  "Bay",
+            "Ash",   "Opal",  "Quill",  "Rill",  "Sable", "Thorn", "Vale",  "Wren",
+        };
+
+        // Names are reused once the list runs out, with a numeral appended, so a long
+        // pedigree can never run out of names or start repeating ambiguously.
+        public static string At(int index)
+        {
+            if (index < 0) index = 0;
+            int word = index % Words.Length;
+            int lap = index / Words.Length;
+            return lap == 0 ? Words[word] : Words[word] + " " + (lap + 1);
+        }
+
+        public static int Count => Words.Length;
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Genetics/OctopusNames.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Genetics/OctopusNames.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 30673aa73d40fa34f9799916136b7061

--- a/Assets/Scripts/LivingEcosystem/Genetics/OctopusPopulation.cs
+++ b/Assets/Scripts/LivingEcosystem/Genetics/OctopusPopulation.cs
@@ -1,0 +1,764 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem.Genetics
+{
+    // The octopuses, one animal at a time.
+    //
+    // This sits on top of the pool rather than replacing it. Each tick the pool has
+    // already worked out how much food the octopuses collectively got and how much
+    // biomass the shark took from them; this layer decides which individuals ate,
+    // which were caught, which bred and which died, then writes the head count back.
+    // The food web the balance work produced is therefore untouched.
+    //
+    // Selection is not scripted (Design Document 4.3). There is no fitness score
+    // anywhere in this file. A heat-intolerant octopus spends more energy staying
+    // alive in warm water, so it more often starves before it breeds. A poorly
+    // camouflaged one is chosen by the shark more often. Gene frequencies shift
+    // because some individuals leave more descendants than others — which is the
+    // whole of natural selection (Literature 3.6).
+    public class OctopusPopulation
+    {
+        // ── Tunables. The milestone names generation speed as the main risk, and
+        // maturity is the one number that controls it. ────────────────────────
+        public const float MaturityDays = 92f;    // ~3 simulated months (real: about a year)
+        public const float MaxAgeDays   = 330f;   // about a year; most breed and die first
+        public const float BroodDays    = 34f;    // she fasts for the whole of it
+        public const float MaleDeclineDays = 26f; // he declines after mating, then dies
+        public const int   MaxAgents    = 5;      // with the shark, 9 or fewer live agents
+                                          // (the design allows 4-8; this reef feeds about five,
+                                          //  which is exactly where Step 1's pool balanced)
+        public const int   MinBrood     = 2;
+        public const int   MaxBrood     = 4;
+        public const float BreedingCondition = 1.20f;  // of a maximum of 2
+        public const float PreyNeededToBreed = 0.45f;  // share of a healthy reef's prey
+
+        // Chance per day that a female who could breed actually does. Multiplied by
+        // up to four as she ages, so most breed before they die of old age but at
+        // scattered times rather than all at once.
+        public const float DailyBreedingChance = 0.014f;
+        public const float Reserves = 12f;             // days of upkeep an octopus carries
+
+        // Settlement from the plankton.
+        //
+        // Octopus young drift for around sixty-five days before settling to the
+        // seafloor (Literature 4.8), which means a reef is not a closed box: it
+        // receives young spawned elsewhere. Modelling that is not a convenience, it
+        // is the mechanism that keeps a real patch of reef occupied.
+        //
+        // It matters doubly here. Five agents is a very small population, and a
+        // semelparous one breeds and dies in cohorts — so a single failed brood, or
+        // one generation ageing out together, ends the line for good.
+        //
+        // Deliberately a last resort, triggered only when the reef is down to its
+        // final animal. Settlers carry whatever the wider sea carries, which is an
+        // even mix, so a steady trickle of them drags every allele frequency towards
+        // fifty percent — strongly enough, at this population size, to cancel out the
+        // selection the learner is supposed to be watching.
+        public const float SettlementIntervalDays = 38f;
+        public const int   SettlementBelow = 2;
+
+        // Raised far above reality so new variation is visible within a session, but
+        // not so far that it drowns the thing it is meant to reveal. Mutation pushes
+        // an allele towards an even split; at 3.5% per transmission that pressure was
+        // comparable to the selection acting on heat tolerance, and warming barely
+        // moved the frequency. Around a hundredth is still thousands of times the real
+        // rate. The interface says the rate is raised wherever it matters
+        // (Literature 3.5).
+        public const float MutationRate = 0.012f;
+
+        public const int GenerationCap = 8;       // older generations collapse to a summary
+
+        public readonly List<OctopusAgent> agents = new List<OctopusAgent>(MaxAgents);
+        public readonly List<AncestorRecord> ancestors = new List<AncestorRecord>(64);
+        // Where life-cycle events are recorded. Set by whoever owns this
+        // population; nothing here depends on it existing.
+        public Memory.ReefJournal journal;
+
+        System.Random _rng;
+        int _nextId;
+        int _nextNameIndex;
+        readonly Dictionary<int, int> _nameIndexById = new Dictionary<int, int>(64);
+
+        // Prey biomass a healthy reef carries, worked out once from the species
+        // table. Breeding is measured against this rather than against a bare count.
+        float _preyBaseline;
+        float _settlementTimer;
+
+        public int NextId => _nextId;
+        public int NextNameIndex => _nextNameIndex;
+
+        public int NameIndexOf(int id) =>
+            _nameIndexById.TryGetValue(id, out int index) ? index : 0;
+
+        public int HighestGeneration { get; private set; }
+        public int TotalBorn { get; private set; }
+        public int TotalDied { get; private set; }
+
+        public int AliveCount
+        {
+            get
+            {
+                int n = 0;
+                for (int i = 0; i < agents.Count; i++) if (agents[i].IsAlive) n++;
+                return n;
+            }
+        }
+
+        // ── Founding ─────────────────────────────────────────────────────────
+
+        // Seeds the founders with every variant present.
+        //
+        // Selection can only act on variation that already exists (Literature 3.7).
+        // A founding population that happens to be all one genotype can never evolve,
+        // and the feature would look broken rather than finished — so the founders are
+        // laid out to guarantee variety rather than left to chance.
+        public void Found(int count, int seed)
+        {
+            agents.Clear();
+            ancestors.Clear();
+            _nameIndexById.Clear();
+            _rng = new System.Random(seed ^ 0x0C7095);
+            _nextId = 0;
+            _nextNameIndex = 0;
+            HighestGeneration = 0;
+            TotalBorn = 0;
+            TotalDied = 0;
+
+            count = Mathf.Clamp(count, 2, MaxAgents);
+
+            // A spread that guarantees both camouflage variants and all three levels
+            // of each additive gene are present from day zero.
+            // Laid out so that no variant is confined to one sex. Sexes alternate
+            // down this list, and an earlier arrangement happened to give both
+            // heat-tolerant genotypes to females — so in warm water the only animals
+            // that survived could not pass the tolerant allele on, and the population
+            // died out having never evolved. Every gene now has both its variants
+            // represented among the males and among the females.
+            var plan = new (int cam, int size, int heat)[]
+            {
+                (1, 1, 1),   // F  Aa Bb Cc — carries everything
+                (2, 0, 2),   // M  AA bb CC — tolerant male
+                (0, 2, 0),   // F  aa BB cc — the weak-camouflage variant, in the open
+                (1, 2, 1),   // M
+                (2, 1, 2),   // F  tolerant female
+                (0, 1, 1),   // M  carries the weak-camouflage variant
+                (1, 0, 0),   // F
+                (2, 2, 1),   // M
+            };
+
+            for (int i = 0; i < count; i++)
+            {
+                var p = plan[i % plan.Length];
+                var genome = Genome.FromCopies(p.cam, p.size, p.heat);
+                // Alternate the sexes so a founding population always has both.
+                var sex = (i % 2 == 0) ? Sex.Female : Sex.Male;
+                var agent = Create(genome, sex, generation: 1, motherId: -1, fatherId: -1, day: 0);
+
+                // Founders start as adults of mixed ages, so they do not all mature,
+                // breed and die in lockstep.
+                agent.ageDays = MaturityDays * (0.55f + 0.5f * (float)_rng.NextDouble());
+                agents.Add(agent);
+            }
+            HighestGeneration = 1;
+
+            _settlementTimer = 0f;
+            _preyBaseline = 0f;
+            var web = SpeciesLibrary.Web;
+            for (int k = 0; k < web.Length; k++)
+            {
+                if (web[k].predator != SpeciesLibrary.Octopus) continue;
+                var prey = SpeciesLibrary.Get(web[k].prey);
+                if (prey != null) _preyBaseline += prey.startingStock * prey.unitMass;
+            }
+        }
+
+        OctopusAgent Create(Genome genome, Sex sex, int generation, int motherId, int fatherId, int day)
+        {
+            int nameIndex = _nextNameIndex++;
+            var agent = new OctopusAgent
+            {
+                id = _nextId++,
+                nameIndex = nameIndex,
+                name = OctopusNames.At(nameIndex),
+                genome = genome,
+                sex = sex,
+                generation = generation,
+                motherId = motherId,
+                fatherId = fatherId,
+                noiseSeed = (float)_rng.NextDouble(),
+                energy = 1f,
+                bornOnDay = day,
+            };
+            agent.RefreshTraits();
+            _nameIndexById[agent.id] = nameIndex;
+            TotalBorn++;
+            if (generation > HighestGeneration) HighestGeneration = generation;
+            return agent;
+        }
+
+        // Puts a saved population back exactly as it was.
+        //
+        // The pedigree is keyed by id, so the counters have to come back too: restart
+        // them at zero and the next octopus born would reuse a dead one's id, and the
+        // family tree would quietly graft one lineage onto another.
+        public void Restore(OctopusAgent[] living, AncestorRecord[] pedigree,
+                            int nextId, int nextNameIndex,
+                            int highestGeneration, int totalBorn, int totalDied)
+        {
+            agents.Clear();
+            ancestors.Clear();
+            _nameIndexById.Clear();
+
+            if (living != null)
+                foreach (var a in living)
+                {
+                    agents.Add(a);
+                    _nameIndexById[a.id] = a.nameIndex;
+                }
+
+            if (pedigree != null)
+                foreach (var r in pedigree)
+                {
+                    ancestors.Add(r);
+                    if (!_nameIndexById.ContainsKey(r.id)) _nameIndexById[r.id] = r.nameIndex;
+                }
+
+            _nextId = Mathf.Max(nextId, 0);
+            _nextNameIndex = Mathf.Max(nextNameIndex, 0);
+            HighestGeneration = Mathf.Max(1, highestGeneration);
+            TotalBorn = totalBorn;
+            TotalDied = totalDied;
+
+            // Seeded from where the reef left off, so a restored session does not
+            // replay the same rolls the last one made.
+            _rng = new System.Random(nextId * 7919 + highestGeneration * 104729 + totalBorn);
+            _settlementTimer = 0f;
+
+            _preyBaseline = 0f;
+            var web = SpeciesLibrary.Web;
+            for (int k = 0; k < web.Length; k++)
+            {
+                if (web[k].predator != SpeciesLibrary.Octopus) continue;
+                var prey = SpeciesLibrary.Get(web[k].prey);
+                if (prey != null) _preyBaseline += prey.startingStock * prey.unitMass;
+            }
+        }
+
+        // ── One simulated day ────────────────────────────────────────────────
+
+        public void Tick(EcosystemSimulation sim, int speciesIndex)
+        {
+            var def = SpeciesLibrary.Get(speciesIndex);
+            if (def == null) return;
+
+            if (!sim.IsPresent(speciesIndex))
+            {
+                if (agents.Count > 0)
+                {
+                    for (int i = 0; i < agents.Count; i++)
+                        Retire(agents[i], CauseOfDeath.Predated, sim.day);
+                    agents.Clear();
+                }
+                WriteBack(sim, speciesIndex, def);
+                return;
+            }
+
+            float metabolic = EcosystemBounds.MetabolicFactor(sim.temperatureC);
+
+            if (agents.Count > 0)
+            {
+                Feed(sim, speciesIndex, def, metabolic);
+                Predation(sim, speciesIndex, def);
+                LiveAndDie(sim, def, metabolic);
+                Breed(sim, def);
+            }
+
+            // Settlement runs even when the reef is empty. A patch of seafloor that
+            // has lost its octopuses is not sterile — it is somewhere young drifting
+            // in from elsewhere can settle, which is how a real reef is recolonised.
+            Settle(sim, def);
+
+            WriteBack(sim, speciesIndex, def);
+        }
+
+        // Shares out what the pool actually caught. A bigger octopus is the better
+        // hunter, so it takes a larger share — and pays for it in the next step.
+        void Feed(EcosystemSimulation sim, int speciesIndex, SpeciesDefinition def, float metabolic)
+        {
+            float caught = sim.pools[speciesIndex].intake;
+
+            float totalShare = 0f;
+            for (int i = 0; i < agents.Count; i++)
+            {
+                var a = agents[i];
+                // A brooding female does not eat at all. She fans the eggs, cleans
+                // them, defends them, and starves while she does it (Literature 4.8).
+                // Size decides how good a hunter it is, but a day's hunting also
+                // has luck in it. Without that variation every octopus runs an
+                // identical energy budget and, when food tightens, they all cross
+                // zero on the same day and the species vanishes in one step instead
+                // of thinning to what the reef can feed.
+                a.huntingShare = a.IsBrooding
+                    ? 0f
+                    : a.traits.bodySize * (0.75f + 0.5f * (float)_rng.NextDouble());
+                totalShare += a.huntingShare;
+            }
+
+            for (int i = 0; i < agents.Count; i++)
+            {
+                var a = agents[i];
+
+                // A brooding female is outside the feeding economy entirely. She is
+                // living off reserves, and that drain is applied once, in LiveAndDie.
+                // Running her through the normal equation as well — no intake, full
+                // cost — burned her out in two days and no brood ever hatched.
+                if (a.IsBrooding)
+                {
+                    a.state = OctopusState.Brooding;
+                    continue;
+                }
+
+                float got = totalShare > 1e-6f ? caught * (a.huntingShare / totalShare) : 0f;
+                float gain = got * def.assimilation;
+
+                // What it costs this individual to stay alive today. Heat tolerance
+                // enters here and nowhere else: in warm water an intolerant animal
+                // simply burns more, and the consequences follow on their own.
+                // HeatCost already carries the whole temperature effect, tolerance
+                // included, so the pool's shared metabolic factor is not applied again.
+                float cost = def.livingCost * a.traits.bodySize
+                           * HeatCost(sim.temperatureC, a.traits.heatTolerance);
+
+                // Energy is a running store, not a bank: it saturates, so a well-fed
+                // octopus cannot hoard its way through an arbitrarily long famine.
+                //
+                // Reserves is how many days of its own upkeep an animal carries. At
+                // one day's worth a single thin week killed the whole population and
+                // there was nothing left to evolve; a real octopus goes weeks without
+                // eating, and a brooding female does exactly that on purpose.
+                float delta = (gain - cost) / Mathf.Max(1e-4f, def.livingCost * Reserves);
+                a.energy = Mathf.Clamp(a.energy + delta, 0f, 2f);
+                a.state = a.IsBrooding ? OctopusState.Brooding
+                        : got > 0f ? OctopusState.Hunting
+                        : OctopusState.Resting;
+            }
+        }
+
+        // What a day of staying alive costs this individual, relative to a
+        // comfortable reef.
+        //
+        // Warming raises the metabolic rate of a cold-blooded animal, so it needs
+        // more food simply to exist (Literature 2.9) — and heat tolerance is
+        // precisely the ability to feel that less. Applying the temperature rise
+        // equally to everyone and then adding a separate penalty for the intolerant
+        // was wrong twice over: a perfectly heat-tolerant octopus still starved at
+        // 30 C, so the trait it is being selected for did not actually save it.
+        //
+        // Below the comfortable temperature nothing is charged, which is why warming
+        // the water is what spreads the tolerant variant and leaving it alone is not.
+        public static float HeatCost(float temperatureC, float heatTolerance)
+        {
+            const float comfortable = 24f;
+            float excess = Mathf.Max(0f, temperatureC - comfortable);
+            if (excess <= 0f) return 1f;
+
+            // A tolerant animal pays a quarter of what an intolerant one pays.
+            float perDegree = 0.10f * (1f - 0.78f * Mathf.Clamp01(heatTolerance));
+            return 1f + excess * perDegree;
+        }
+
+        // The shark took a certain amount of octopus biomass. Which octopuses?
+        // The poorly camouflaged ones, more often.
+        void Predation(EcosystemSimulation sim, int speciesIndex, SpeciesDefinition def)
+        {
+            float taken = sim.pools[speciesIndex].removed;
+            if (taken <= 0f) return;
+
+            int guard = 0;
+            while (taken > 0f && agents.Count > 0 && guard++ < MaxAgents * 2)
+            {
+                // Weighted draw: exposure is the inverse of camouflage, so a weakly
+                // camouflaged animal is several times likelier to be the one caught.
+                float total = 0f;
+                for (int i = 0; i < agents.Count; i++)
+                    total += Exposure(agents[i]);
+                if (total <= 1e-6f) break;
+
+                float roll = (float)_rng.NextDouble() * total;
+                int victim = agents.Count - 1;
+                for (int i = 0; i < agents.Count; i++)
+                {
+                    roll -= Exposure(agents[i]);
+                    if (roll <= 0f) { victim = i; break; }
+                }
+
+                var caught = agents[victim];
+                float mass = caught.Mass(def.unitMass);
+                // Only actually taken if the shark's remaining appetite covers a
+                // decent share of this animal; otherwise it got away.
+                if (taken < mass * 0.5f)
+                {
+                    // It got away. Never overwrite a brooding female's state — she is
+                    // in her den, and what she is doing matters more than the near miss.
+                    if (!caught.IsBrooding) caught.state = OctopusState.Fleeing;
+                    break;
+                }
+
+                taken -= mass;
+                Retire(caught, CauseOfDeath.Predated, sim.day);
+                agents.RemoveAt(victim);
+            }
+        }
+
+        static float Exposure(OctopusAgent a)
+        {
+            // A brooding female is in her den and much harder to find, which is one
+            // reason brooding is worth the starvation.
+            float hidden = a.IsBrooding ? 0.35f : 1f;
+            return Mathf.Max(0.05f, (1.05f - a.traits.camouflage)) * hidden;
+        }
+
+        void LiveAndDie(EcosystemSimulation sim, SpeciesDefinition def, float metabolic)
+        {
+            for (int i = agents.Count - 1; i >= 0; i--)
+            {
+                var a = agents[i];
+                a.ageDays += 1f;
+
+                if (a.IsBrooding)
+                {
+                    a.broodDaysRemaining -= 1f;
+                    // She loses a large fraction of her body weight while brooding.
+                    a.energy = Mathf.Max(0f, a.energy - 0.028f);
+                    if (a.broodDaysRemaining <= 0f)
+                    {
+                        Hatch(a, sim, def);
+                        // Within days of the eggs hatching, she dies. This is real,
+                        // and it is what makes the feature work.
+                        Retire(a, CauseOfDeath.AfterBreeding, sim.day);
+                        agents.RemoveAt(i);
+                        continue;
+                    }
+                    continue;
+                }
+
+                if (a.HasMated)
+                {
+                    a.declineDaysRemaining -= 1f;
+                    // He eats less and less as he declines; this is programmed, not
+                    // accidental (Literature 4.8, the optic gland).
+                    a.energy = Mathf.Max(0f, a.energy - 0.012f);
+                    if (a.declineDaysRemaining <= 0f)
+                    {
+                        Retire(a, CauseOfDeath.AfterBreeding, sim.day);
+                        agents.RemoveAt(i);
+                        continue;
+                    }
+                }
+
+                if (a.energy <= 0.02f)
+                {
+                    Retire(a, CauseOfDeath.Starved, sim.day);
+                    agents.RemoveAt(i);
+                    continue;
+                }
+
+                if (a.ageDays >= MaxAgeDays)
+                {
+                    Retire(a, CauseOfDeath.OldAge, sim.day);
+                    agents.RemoveAt(i);
+                }
+            }
+        }
+
+        void Breed(EcosystemSimulation sim, SpeciesDefinition def)
+        {
+            if (agents.Count >= MaxAgents) return;
+
+            // A floor, not the main regulator: octopuses do not breed on a reef
+            // that has been stripped. The real density control is the condition
+            // requirement above — now that an octopus carries a dozen days of
+            // reserves, its energy takes months to climb when food is tight and only
+            // days when it is plentiful, which makes it an honest measure of how
+            // crowded the reef is. Judging instead against a fixed healthy-reef
+            // figure blocked breeding outright in warm water, where the reef simply
+            // never reaches that figure.
+            float preyNow = 0f;
+            var web = SpeciesLibrary.Web;
+            for (int k = 0; k < web.Length; k++)
+            {
+                if (web[k].predator != SpeciesLibrary.Octopus) continue;
+                if (!sim.IsPresent(web[k].prey)) continue;
+                preyNow += sim.pools[web[k].prey].biomass;
+            }
+            if (_preyBaseline > 0f && preyNow < _preyBaseline * PreyNeededToBreed) return;
+
+            OctopusAgent female = null, male = null;
+            for (int i = 0; i < agents.Count; i++)
+            {
+                var a = agents[i];
+                if (!a.IsAlive || a.IsBrooding) continue;
+                if (!a.IsMature(MaturityDays)) continue;
+                // She must be in real condition, not merely fed: brooding means a
+                // month without eating. Requiring a surplus rather than a living wage
+                // is also what stops the population breeding itself up to the cap and
+                // straight into a famine.
+                if (a.energy < BreedingCondition) continue;
+
+                if (a.sex == Sex.Female && female == null) female = a;
+                else if (a.sex == Sex.Male && male == null) male = a;
+            }
+
+            if (female == null || male == null) return;
+
+            // Being able to breed is not the same as breeding today.
+            //
+            // Pairing off the first eligible female with the first eligible male on
+            // the very tick both qualified meant the whole reef bred within days of
+            // maturing, brooded together and died together — one synchronised cohort,
+            // which is neither what a real population does nor something a learner
+            // can read. It also drowned out the pair they had deliberately chosen.
+            //
+            // Instead each ready female has a modest chance each day, rising as she
+            // ages: breeding once is the last thing an octopus does, and one running
+            // out of time is likelier to do it. Animals therefore breed at their own
+            // times, and the pair the learner picks is the event that stands out.
+            float pastMaturity = Mathf.Clamp01((female.ageDays - MaturityDays) /
+                                               Mathf.Max(1f, MaxAgeDays - MaturityDays));
+            float chanceToday = DailyBreedingChance * (1f + pastMaturity * 3f);
+            if (_rng.NextDouble() > chanceToday) return;
+
+            StartBrood(female, male, sim, def);
+        }
+
+        // Made public so the breeding tool can pair two animals the learner chose.
+        public bool StartBrood(OctopusAgent female, OctopusAgent male,
+                               EcosystemSimulation sim, SpeciesDefinition def)
+        {
+            if (female == null || male == null) return false;
+            if (female.sex != Sex.Female || male.sex != Sex.Male) return false;
+            if (!female.IsAlive || !male.IsAlive) return false;
+            if (female.IsBrooding) return false;
+            if (!female.IsMature(MaturityDays) || !male.IsMature(MaturityDays)) return false;
+
+            female.state = OctopusState.Brooding;
+            female.broodDaysRemaining = BroodDays;
+            female.mateId = male.id;
+            female.pendingYoung = _rng.Next(MinBrood, MaxBrood + 1);
+            // The genome she will breed from is fixed at mating: the male transfers
+            // sperm packets with his hectocotylus and she stores them, so his dying
+            // first does not stop the brood.
+            female.storedMate = male.genome;
+            female.storedMateId = male.id;
+
+            // He starts declining, rather than dropping where he stands. He is still
+            // usually dead well before the eggs hatch, but he may father another
+            // brood first — which is what real males do, and what keeps a population
+            // of half a dozen from stalling the moment its one male mates.
+            male.state = OctopusState.Mating;
+            if (!male.HasMated) male.declineDaysRemaining = MaleDeclineDays;
+
+            Record(Memory.ReefEventKind.OctopusMated, sim.day, female.id, 0, male.id);
+            return true;
+        }
+
+        // A young octopus arrives from the plankton and settles on this reef.
+        void Settle(EcosystemSimulation sim, SpeciesDefinition def)
+        {
+            // The clock runs whether or not the reef needs a settler, so one is
+            // already due the moment the population drops. Resetting it on every
+            // recovery meant a crash from five to none — which takes about six weeks
+            // — always outran the settlement it was supposed to trigger.
+            _settlementTimer += 1f;
+
+            if (agents.Count >= SettlementBelow || agents.Count >= MaxAgents) return;
+            if (_settlementTimer < SettlementIntervalDays) return;
+            _settlementTimer = 0f;
+
+            // It only settles where there is something to eat.
+            float preyNow = 0f;
+            var web = SpeciesLibrary.Web;
+            for (int k = 0; k < web.Length; k++)
+            {
+                if (web[k].predator != SpeciesLibrary.Octopus) continue;
+                if (!sim.IsPresent(web[k].prey)) continue;
+                preyNow += sim.pools[web[k].prey].biomass;
+            }
+            if (_preyBaseline > 0f && preyNow < _preyBaseline * 0.35f) return;
+
+            // A settler carries whatever the wider sea carries.
+            var genome = Genome.Random(_rng);
+
+            // Its sex is a coin toss, except that a reef holding only one sex gets
+            // the other — a disclosed nudge, because with a population this small an
+            // unlucky run of one sex is a dead end the learner can do nothing about.
+            Sex sex;
+            bool anyFemale = false, anyMale = false;
+            for (int i = 0; i < agents.Count; i++)
+            {
+                if (agents[i].sex == Sex.Female) anyFemale = true; else anyMale = true;
+            }
+            if (anyFemale && !anyMale) sex = Sex.Male;
+            else if (anyMale && !anyFemale) sex = Sex.Female;
+            else sex = _rng.NextDouble() < 0.5 ? Sex.Female : Sex.Male;
+
+            var settler = Create(genome, sex, Mathf.Max(1, HighestGeneration), -1, -1, sim.day);
+            settler.ageDays = MaturityDays * 0.4f;   // it has already drifted for weeks
+            agents.Add(settler);
+            Record(Memory.ReefEventKind.OctopusSettled, sim.day, settler.id);
+        }
+
+        void Hatch(OctopusAgent mother, EcosystemSimulation sim, SpeciesDefinition def)
+        {
+            int room = Mathf.Max(0, MaxAgents - (agents.Count - 1));
+            int young = Mathf.Min(mother.pendingYoung, room);
+            int generation = mother.generation + 1;
+
+            // Sexes alternate within a brood rather than being drawn independently.
+            // The expected ratio is still even, but in a brood of two or three an
+            // independent draw quite often produces one sex only, and in a population
+            // this small that ends the line. A disclosed simplification.
+            var firstSex = _rng.NextDouble() < 0.5 ? Sex.Female : Sex.Male;
+
+            for (int i = 0; i < young; i++)
+            {
+                var genome = Genome.Inherit(mother.storedMate, mother.genome, _rng, MutationRate);
+                var sex = (i % 2 == 0) ? firstSex
+                                       : (firstSex == Sex.Female ? Sex.Male : Sex.Female);
+                var child = Create(genome, sex, generation, mother.id, mother.storedMateId, sim.day);
+                agents.Add(child);
+            }
+
+            if (young > 0)
+            {
+                Record(Memory.ReefEventKind.OctopusHatched, sim.day, mother.id, young, generation);
+                Record(Memory.ReefEventKind.NewGeneration, sim.day, -1, generation);
+            }
+        }
+
+        void Retire(OctopusAgent a, CauseOfDeath cause, int day)
+        {
+            a.state = OctopusState.Dead;
+            a.causeOfDeath = cause;
+            a.diedOnDay = day;
+            TotalDied++;
+
+            int nameIndex = _nameIndexById.TryGetValue(a.id, out int idx) ? idx : 0;
+            ancestors.Add(AncestorRecord.From(a, nameIndex));
+            TrimAncestors();
+
+            Record(Memory.ReefEventKind.OctopusDied, day, a.id, (int)cause);
+        }
+
+        // History is capped at the most recent eight generations, which keeps the
+        // pedigree bounded at well under a kilobyte however long the session runs.
+        void TrimAncestors()
+        {
+            int oldestKept = HighestGeneration - GenerationCap;
+            if (oldestKept <= 0) return;
+            ancestors.RemoveAll(r => r.generation < oldestKept);
+        }
+
+        void Record(Memory.ReefEventKind kind, int day, int subject, int value = 0, int other = -1)
+        {
+            journal?.Add(kind, day, subject, value, other);
+        }
+
+        // Hands the head count and biomass back to the pool, so the rest of the food
+        // web sees the octopuses exactly as it did before they became individuals.
+        void WriteBack(EcosystemSimulation sim, int speciesIndex, SpeciesDefinition def)
+        {
+            float biomass = 0f;
+            for (int i = 0; i < agents.Count; i++) biomass += agents[i].Mass(def.unitMass);
+
+            sim.pools[speciesIndex].count = agents.Count;
+            sim.pools[speciesIndex].biomass = biomass;
+        }
+
+        // ── Readouts for the interface ───────────────────────────────────────
+
+        public OctopusAgent ById(int id)
+        {
+            for (int i = 0; i < agents.Count; i++) if (agents[i].id == id) return agents[i];
+            return null;
+        }
+
+        public bool TryAncestor(int id, out AncestorRecord record)
+        {
+            for (int i = 0; i < ancestors.Count; i++)
+                if (ancestors[i].id == id) { record = ancestors[i]; return true; }
+            record = default;
+            return false;
+        }
+
+        public string NameOf(int id)
+        {
+            var live = ById(id);
+            if (live != null) return live.name;
+            if (TryAncestor(id, out var rec)) return rec.Name;
+            return "unknown";
+        }
+
+        // Share of alleles in the living population that are the uppercase variant.
+        // This is the number that visibly moves when the learner warms the water.
+        public float AlleleFrequency(GeneId gene)
+        {
+            int copies = 0, total = 0;
+            for (int i = 0; i < agents.Count; i++)
+            {
+                if (!agents[i].IsAlive) continue;
+                copies += agents[i].genome.CopiesOf(gene);
+                total += 2;
+            }
+            return total > 0 ? copies / (float)total : 0f;
+        }
+
+        // Share of living animals showing the dominant phenotype, which for
+        // camouflage is not the same as the allele frequency — a distinction the
+        // inspector makes explicitly.
+        public float StrongCamouflageShare()
+        {
+            int strong = 0, total = 0;
+            for (int i = 0; i < agents.Count; i++)
+            {
+                if (!agents[i].IsAlive) continue;
+                total++;
+                if (agents[i].genome.CopiesOf(GeneId.Camouflage) >= 1) strong++;
+            }
+            return total > 0 ? strong / (float)total : 0f;
+        }
+
+        public float AverageTrait(GeneId gene)
+        {
+            float sum = 0f; int n = 0;
+            for (int i = 0; i < agents.Count; i++)
+            {
+                if (!agents[i].IsAlive) continue;
+                sum += agents[i].traits.ValueOf(gene);
+                n++;
+            }
+            return n > 0 ? sum / n : 0f;
+        }
+
+        // True when every variant of every gene is present somewhere in the living
+        // population. The milestone asks for an automated check that variety exists
+        // on day zero, because without it nothing can ever evolve.
+        public bool HasFullVariety()
+        {
+            foreach (GeneId gene in System.Enum.GetValues(typeof(GeneId)))
+            {
+                bool sawUpper = false, sawLower = false;
+                for (int i = 0; i < agents.Count; i++)
+                {
+                    if (!agents[i].IsAlive) continue;
+                    int copies = agents[i].genome.CopiesOf(gene);
+                    if (copies >= 1) sawUpper = true;
+                    if (copies <= 1) sawLower = true;
+                }
+                if (!sawUpper || !sawLower) return false;
+            }
+            return true;
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Genetics/OctopusPopulation.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Genetics/OctopusPopulation.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7546351ea0a07c34a9f2ffaf992ac031

--- a/Assets/Scripts/LivingEcosystem/Genetics/OctopusTraits.cs
+++ b/Assets/Scripts/LivingEcosystem/Genetics/OctopusTraits.cs
@@ -1,0 +1,83 @@
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem.Genetics
+{
+    // Turns a genotype into what the animal actually is (Literature 3.1: the pair of
+    // variants is the genotype, what it produces is the phenotype).
+    //
+    // A small random component is added on top of every trait, so two animals with
+    // identical genes are not quite identical. One line of code, and one of the most
+    // commonly misunderstood ideas in school biology: genotype is not destiny
+    // (Design Document 4.1). The component is drawn once at birth and kept, so an
+    // individual stays itself.
+    public struct OctopusTraits
+    {
+        public float camouflage;    // 0 poor .. 1 excellent
+        public float bodySize;      // multiplier on the model and on appetite
+        public float heatTolerance; // 0 intolerant .. 1 tolerant
+
+        // How much of each trait is individual variation rather than genotype.
+        public const float CamouflageNoise = 0.08f;
+        public const float BodySizeNoise   = 0.05f;
+        public const float HeatNoise       = 0.07f;
+
+        public static OctopusTraits From(Genome genome, float noiseSeed01)
+        {
+            // One stored number drives all three wobbles, so an individual needs a
+            // single byte of "not quite its genotype" rather than three.
+            float n1 = Wobble(noiseSeed01, 0.13f);
+            float n2 = Wobble(noiseSeed01, 0.47f);
+            float n3 = Wobble(noiseSeed01, 0.79f);
+
+            var t = new OctopusTraits();
+
+            // Camouflage is dominant: one strong copy is enough. The heterozygote is
+            // deliberately NOT midway — that is what dominance means, and showing Aa
+            // as identical to AA is what makes the recessive copy's reappearance
+            // surprising later.
+            bool strong = genome.CopiesOf(GeneId.Camouflage) >= 1;
+            t.camouflage = Mathf.Clamp01((strong ? 0.86f : 0.30f) + n1 * CamouflageNoise);
+
+            // Additive: 0, 1 or 2 copies spread across a range.
+            int sizeCopies = genome.CopiesOf(GeneId.BodySize);
+            t.bodySize = Mathf.Clamp(0.80f + sizeCopies * 0.20f + n2 * BodySizeNoise, 0.6f, 1.5f);
+
+            int heatCopies = genome.CopiesOf(GeneId.HeatTolerance);
+            t.heatTolerance = Mathf.Clamp01(heatCopies * 0.5f + n3 * HeatNoise);
+
+            return t;
+        }
+
+        // A repeatable pseudo-random value in -1..1 from a stored 0..1 seed.
+        static float Wobble(float seed01, float salt)
+        {
+            float v = Mathf.Sin((seed01 + salt) * 127.1f) * 43758.5453f;
+            return (v - Mathf.Floor(v)) * 2f - 1f;
+        }
+
+        // ── Plain-language descriptions, for the inspector ───────────────────
+
+        public string CamouflageWord =>
+            camouflage > 0.65f ? "Strong" : camouflage > 0.45f ? "Moderate" : "Weak";
+
+        public string BodySizeWord =>
+            bodySize > 1.12f ? "Large" : bodySize > 0.95f ? "Medium" : "Small";
+
+        public string HeatToleranceWord =>
+            heatTolerance > 0.66f ? "High" : heatTolerance > 0.33f ? "Moderate" : "Low";
+
+        public float ValueOf(GeneId gene) => gene switch
+        {
+            GeneId.Camouflage    => camouflage,
+            GeneId.BodySize      => Mathf.InverseLerp(0.6f, 1.5f, bodySize),
+            _                    => heatTolerance,
+        };
+
+        public string WordFor(GeneId gene) => gene switch
+        {
+            GeneId.Camouflage    => CamouflageWord,
+            GeneId.BodySize      => BodySizeWord,
+            _                    => HeatToleranceWord,
+        };
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Genetics/OctopusTraits.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Genetics/OctopusTraits.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 53fc4c2ccf4e3624d9189d2a8c8b6be3

--- a/Assets/Scripts/LivingEcosystem/LivingReefBootstrap.cs
+++ b/Assets/Scripts/LivingEcosystem/LivingReefBootstrap.cs
@@ -1,0 +1,128 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace CreateEnv.Ecosystem
+{
+    // Installs the Living Reef into FreeExploreEndless, and nowhere else.
+    //
+    // This runs itself. There is no component to add to a scene, no prefab to edit
+    // and no Addressable group to touch — which matters, because the target scene is
+    // an Addressable and every widget added by hand would be a change to its
+    // serialized data. The whole feature is therefore additive: if it is switched
+    // off, or if this file were deleted, the scene behaves exactly as it does today.
+    //
+    // Scope is deliberately narrow. Only FreeExploreEndless is touched. FreeExplore
+    // is a separate scene with its own logic and is explicitly left alone.
+    public static class LivingReefBootstrap
+    {
+        // The one scene the ecosystem may install itself into.
+        //
+        // Matched case-insensitively on purpose: the asset on disk is
+        // "freeExploreEndless.unity" while every reference in code spells it
+        // "FreeExploreEndless". Scene.name comes from the file, so an ordinary ==
+        // never matches and the reef silently never installs.
+        public const string TargetScene = "FreeExploreEndless";
+
+        static LivingReefController _active;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        static void Hook()
+        {
+            // Statics survive between play sessions when domain reload is turned off,
+            // so this could otherwise start holding a destroyed controller.
+            _active = null;
+
+            SceneManager.sceneLoaded -= OnSceneLoaded;
+            SceneManager.sceneLoaded += OnSceneLoaded;
+
+            // Cover the case where the target scene is already the one running (for
+            // example, pressing Play on it directly in the Editor).
+            var active = SceneManager.GetActiveScene();
+            if (IsTarget(active)) TryInstall();
+        }
+
+        static void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            // A single-mode load has already destroyed the previous reef.
+            if (mode == LoadSceneMode.Single) _active = null;
+
+            if (!IsTarget(scene)) return;
+            TryInstall();
+        }
+
+        static bool IsTarget(Scene scene) =>
+            scene.IsValid() &&
+            string.Equals(scene.name, TargetScene, System.StringComparison.OrdinalIgnoreCase);
+
+        static void TryInstall()
+        {
+            if (_active != null) return;
+
+            var settings = ResolveSettings();
+            if (settings == null || !settings.enabled) return;
+
+            // Guard against a second install if the scene is reloaded quickly.
+            if (Object.FindFirstObjectByType<LivingReefController>() != null) return;
+
+            int seed = ResolveSeed();
+            _active = LivingReefController.Install(settings, seed, true, ResolveEnvironmentId());
+            Debug.Log($"[LivingReef] Installed in {TargetScene} with seed {seed}. " +
+                      "Open the 'Reef' tab on the right-hand edge of the screen.");
+        }
+
+        // The ecosystem rides inside the environment profile the learner chose, so it
+        // arrives through machinery that already exists. When no profile is selected
+        // (a built-in environment, or entering the scene directly), the feature stays
+        // off and nothing changes.
+        //
+        // Every way of declining says why. A feature that silently does nothing is
+        // indistinguishable from a broken one, and this one has several perfectly
+        // legitimate reasons not to start.
+        static EcosystemSettings ResolveSettings()
+        {
+            var profile = EnvironmentSession.Selected;
+            if (profile == null)
+            {
+                Debug.Log("[LivingReef] No environment profile selected, so the ecosystem is not " +
+                          "running. Built-in environments do not carry one — make an environment in " +
+                          "Create Environment and play that instead.");
+                return null;
+            }
+
+            if (profile.ecosystem == null)
+            {
+                Debug.Log($"[LivingReef] '{profile.displayName}' was saved before the Living Ecosystem " +
+                          "existed. Open it in Create Environment, switch the ecosystem on, and save.");
+                return null;
+            }
+
+            if (!profile.ecosystem.enabled)
+            {
+                Debug.Log($"[LivingReef] The Living Ecosystem is switched off for " +
+                          $"'{profile.displayName}'. Open it in Create Environment, scroll to " +
+                          "'Living Ecosystem' and set 'Enable living ecosystem' to On.");
+                return null;
+            }
+
+            var settings = profile.ecosystem.Clone();
+            settings.Clamp();
+            return settings;
+        }
+
+        // Which saved reef to pick up. Each environment keeps its own, so a learner
+        // with several worlds finds each of them as they left it.
+        static string ResolveEnvironmentId()
+        {
+            var profile = EnvironmentSession.Selected;
+            return profile != null && !string.IsNullOrEmpty(profile.id) ? profile.id : null;
+        }
+
+        // Seeded from the environment, so the same environment replays identically
+        // and bugs are reproducible (Design Document 3.2).
+        static int ResolveSeed()
+        {
+            var profile = EnvironmentSession.Selected;
+            return profile != null ? profile.seed : 0;
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/LivingReefBootstrap.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/LivingReefBootstrap.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 091b8a7ef1564b04481a889a4d3981a4

--- a/Assets/Scripts/LivingEcosystem/LivingReefController.cs
+++ b/Assets/Scripts/LivingEcosystem/LivingReefController.cs
@@ -1,0 +1,276 @@
+using CreateEnv.Ecosystem.UI;
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem
+{
+    // Owns the running ecosystem: the simulation, the clock, the health tracker, the
+    // reasoning rules, the rewind buffer, the renderer and the interface.
+    //
+    // One component, created at runtime by LivingReefBootstrap. Nothing else in the
+    // project holds a reference to it, so if the feature is off, none of this exists
+    // and Shallow Sand behaves exactly as it does today.
+    [DefaultExecutionOrder(200)]
+    public class LivingReefController : MonoBehaviour
+    {
+        public EcosystemSettings Settings { get; private set; }
+        public EcosystemSimulation Sim { get; private set; }
+        public EcosystemHealth Health { get; private set; }
+        public ReasonEngine Reasons { get; private set; }
+        public EcosystemClock Clock { get; private set; }
+
+        // Step 2: the octopuses are individuals with genomes rather than a number.
+        public Genetics.OctopusPopulation Octopuses { get; private set; }
+
+        // Step 3: what the reef has been through, and what it remembers.
+        public Memory.ReefChronicle Chronicle { get; private set; }
+
+        RewindBuffer _rewind;
+        PopulationRenderer _renderer;
+        EcosystemPanelUI _panel;
+        BarrenPromptUI _barrenPrompt;
+
+        public bool CanRewind => _rewind != null && _rewind.HasAny;
+
+        // followViewer: true in AR, where the reef is the patch of seafloor around
+        // the learner. False for a fixed-camera preview, where it is pinned in front.
+        public static LivingReefController Install(EcosystemSettings settings, int seed,
+                                                   bool followViewer = true,
+                                                   string environmentId = null)
+        {
+            var go = new GameObject("Living Reef");
+            var reef = go.AddComponent<LivingReefController>();
+            reef._followViewer = followViewer;
+            reef.EnvironmentId = environmentId;
+            reef.Initialise(settings, seed);
+            return reef;
+        }
+
+        // Which saved reef this is. Null means nothing is written down.
+        public string EnvironmentId { get; private set; }
+
+        // What happened while the learner was away, for the Welcome Back card.
+        public Memory.TimeAway.Result Resumed { get; private set; }
+        public int DayOnArrival { get; private set; }
+        public bool HasSomethingToReport { get; private set; }
+
+        // The two octopuses currently chosen in the breeding tool, so the renderer
+        // can light them and the learner can find them in the water.
+        [System.NonSerialized] public int chosenFemaleId = -1;
+        [System.NonSerialized] public int chosenMaleId = -1;
+
+        bool _followViewer = true;
+        bool _waitingForPlacement;
+        float _placementPoll;
+
+        void Initialise(EcosystemSettings settings, int seed)
+        {
+            Settings = settings != null ? settings.Clone() : new EcosystemSettings();
+            Settings.Clamp();
+
+            Sim = new EcosystemSimulation(Settings, seed);
+            Health = new EcosystemHealth();
+            Reasons = new ReasonEngine();
+            Clock = new EcosystemClock { speed = Settings.speed };
+            _rewind = new RewindBuffer();
+
+            // Octopuses become individuals. The pool still speaks to the food web on
+            // their behalf, so the balanced web from Step 1 is unchanged.
+            Chronicle = new Memory.ReefChronicle();
+
+            Octopuses = new Genetics.OctopusPopulation();
+            Octopuses.journal = Chronicle.journal;
+            Sim.agentManaged[SpeciesLibrary.Octopus] = true;
+            if (Sim.IsPresent(SpeciesLibrary.Octopus))
+                Octopuses.Found(Mathf.RoundToInt(Sim.pools[SpeciesLibrary.Octopus].count), seed);
+
+            Health.Reset(Sim);
+            Reasons.Reset();
+            Reasons.Observe(Sim);
+            Reasons.Evaluate(Sim, Health);
+            Chronicle.Begin(Sim, Health, Octopuses);
+            _rewind.Capture(Sim);
+
+            LoadAndCatchUp();
+
+            _renderer = gameObject.AddComponent<PopulationRenderer>();
+            _renderer.followViewer = _followViewer;
+            // The AR path waits for the learner to place the environment; a preview
+            // scene already has its floor, so it can draw straight away.
+            _renderer.requireGround = _followViewer;
+            _renderer.octopuses = Octopuses;
+            _renderer.reef = this;
+            _renderer.Bind(Sim, transform);
+
+            _panel = EcosystemPanelUI.Create(this);
+            _barrenPrompt = GetComponentInChildren<BarrenPromptUI>(true);
+
+            // In AR the whole interface stays hidden until the environment is down.
+            // A preview scene has its floor already, so it starts live.
+            _waitingForPlacement = _followViewer;
+            if (_waitingForPlacement && _panel != null)
+                _panel.gameObject.SetActive(false);
+        }
+
+        void Update()
+        {
+            // Nothing exists until the learner has actually placed the environment.
+            // Detecting a scanned plane is not enough: the reef has no seafloor to
+            // live on until the terrain prefab is instantiated by the placement tap,
+            // and a panel offering to edit an ecosystem that is not there yet reads
+            // as broken. The clock is held too, so day one is the day they arrive.
+            if (_waitingForPlacement)
+            {
+                _placementPoll -= Time.unscaledDeltaTime;
+                if (_placementPoll > 0f) return;
+                _placementPoll = 0.25f;
+
+                if (FindFirstObjectByType<EndlessTerrain>() == null) return;
+
+                _waitingForPlacement = false;
+                if (_panel != null) _panel.gameObject.SetActive(true);
+                Debug.Log("[LivingReef] Environment placed — the reef is now live.");
+                return;
+            }
+
+            int days = Clock.Advance(Time.deltaTime);
+            for (int i = 0; i < days; i++)
+            {
+                Sim.Tick();
+                // The pool has stated its demand and suffered its predation; the
+                // agent layer now decides which individuals that happened to.
+                Octopuses.Tick(Sim, SpeciesLibrary.Octopus);
+                Reasons.Observe(Sim);
+                Health.Evaluate(Sim);
+                Chronicle.Observe(Sim, Health, Octopuses);
+                _rewind.MaybeCapture(Sim);
+            }
+
+            if (days > 0)
+            {
+                Reasons.Evaluate(Sim, Health);
+                if (Health.stage <= CollapseStage.Imbalance && _barrenPrompt != null)
+                    _barrenPrompt.NotifyRecovered();
+            }
+        }
+
+        // ── Memory (Design Document 8) ───────────────────────────────────────
+
+        // Picks up where the reef left off, then runs the days that passed while the
+        // learner was elsewhere.
+        void LoadAndCatchUp()
+        {
+            if (string.IsNullOrEmpty(EnvironmentId)) return;
+
+            var save = Memory.ReefSaveFile.Read(EnvironmentId);
+            if (save == null) return;
+
+            save.ApplyTo(Settings, Sim, Octopuses, Chronicle);
+            Clock.speed = Settings.speed;
+
+            Health.Reset(Sim);
+            Reasons.Reset();
+            Reasons.Observe(Sim);
+
+            DayOnArrival = Sim.day;
+            Resumed = Memory.TimeAway.Measure(save.HoursAway(System.DateTime.UtcNow));
+
+            // The days that passed in the ocean while the app was closed. Capped at a
+            // fortnight however long they were gone, so this is at most fourteen
+            // ordinary ticks — the same arithmetic the live clock runs, just without
+            // anyone watching.
+            for (int i = 0; i < Resumed.daysToRun; i++)
+            {
+                Sim.Tick();
+                Octopuses.Tick(Sim, SpeciesLibrary.Octopus);
+                Reasons.Observe(Sim);
+                Health.Evaluate(Sim);
+                Chronicle.Observe(Sim, Health, Octopuses);
+            }
+
+            Reasons.Evaluate(Sim, Health);
+            HasSomethingToReport = Resumed.worthReporting;
+
+            Debug.Log($"[LivingReef] Resumed '{EnvironmentId}' at day {DayOnArrival}; " +
+                      $"{Resumed.hoursAway:0.0} hours away ran {Resumed.daysToRun} days" +
+                      (Resumed.wasCapped ? " (capped)" : "") + ".");
+        }
+
+        // Written on pause, on backgrounding and on quit — the three ways a session
+        // ends on a phone.
+        public void Save()
+        {
+            if (string.IsNullOrEmpty(EnvironmentId)) return;
+            if (Sim == null) return;
+
+            Memory.ReefSaveFile.Write(
+                Memory.ReefSave.From(EnvironmentId, Settings, Sim, Octopuses, Chronicle));
+        }
+
+        void OnApplicationPause(bool paused) { if (paused) Save(); }
+        void OnApplicationFocus(bool focused) { if (!focused) Save(); }
+        void OnApplicationQuit() => Save();
+        void OnDestroy() => Save();
+
+        public void ClearReport() => HasSomethingToReport = false;
+
+        // ── Live controls (Design Document 6.1) ──────────────────────────────
+        public void SetTemperature(float celsius)
+        {
+            Settings.temperatureC = EcosystemBounds.Temperature.Clamp(celsius);
+            Sim.temperatureC = Settings.temperatureC;
+        }
+
+        public void SetAcidity(float ph)
+        {
+            Settings.acidityPh = EcosystemBounds.Acidity.Clamp(ph);
+            Sim.acidityPh = Settings.acidityPh;
+        }
+
+        public void SetSpeed(int speed)
+        {
+            Settings.speed = Mathf.Clamp(speed, 0, EcosystemSettings.SpeedOptions.Length - 1);
+            Clock.speed = Settings.speed;
+        }
+
+        public void SetSpeciesPresent(int species, bool present)
+        {
+            if (Sim.IsPresent(species) == present) return;
+            Sim.SetPresent(species, present);
+            if (Settings.present != null && species < Settings.present.Length)
+                Settings.present[species] = present;
+            if (_panel != null) _panel.RefreshOrganismRows();
+        }
+
+        // ── Barren-state options ─────────────────────────────────────────────
+        public void RestoreAllSpecies()
+        {
+            for (int i = 0; i < SpeciesLibrary.Count; i++)
+                SetSpeciesPresent(i, true);
+        }
+
+        public void Rewind()
+        {
+            var snapshot = _rewind.Restore(Sim);
+            if (snapshot == null) return;
+
+            Health.Reset(Sim);
+            Reasons.Reset();
+            Reasons.Observe(Sim);
+            Reasons.Evaluate(Sim, Health);
+            if (_panel != null) _panel.RefreshOrganismRows();
+        }
+
+        public void RestartEcosystem()
+        {
+            Sim.Reset(Settings);
+            Health.Reset(Sim);
+            Reasons.Reset();
+            Reasons.Observe(Sim);
+            Reasons.Evaluate(Sim, Health);
+            _rewind.Reset();
+            _rewind.Capture(Sim);
+            Clock.Reset();
+            if (_panel != null) _panel.RefreshOrganismRows();
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/LivingReefController.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/LivingReefController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d4f0c941f1b9e5041b2dcd1b4db85afa

--- a/Assets/Scripts/LivingEcosystem/LivingReefPreview.cs
+++ b/Assets/Scripts/LivingEcosystem/LivingReefPreview.cs
@@ -1,0 +1,107 @@
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem
+{
+    // A development harness for looking at the reef without AR.
+    //
+    // The real feature installs itself only in FreeExploreEndless, and only once the
+    // learner has chosen an environment with the ecosystem switched on. That is the
+    // right behaviour for the app, but it makes the reef awkward to inspect while
+    // building it: pressing Play on the AR scene needs a tracked plane and a tap
+    // before anything happens.
+    //
+    // Drop this on a GameObject in any ordinary scene and press Play. It builds the
+    // same LivingReefController the real bootstrap builds, with the same simulation,
+    // the same meshes and the same panel — just without the AR placement step.
+    //
+    // It does nothing unless you add it deliberately, so it cannot affect the app.
+    public class LivingReefPreview : MonoBehaviour
+    {
+        [Header("Starting conditions")]
+        public bool enableEcosystem = true;
+
+        [Tooltip("0 = Few, 1 = Balanced, 2 = Many")]
+        [Range(0, 2)] public int startingLife = 1;
+
+        [Range(18f, 32f)] public float temperatureC = 24f;
+        [Range(7.6f, 8.3f)] public float acidityPh = 8.1f;
+
+        [Tooltip("0 = Paused, 1 = Normal (2s per day), 2 = Fast (0.25s per day)")]
+        [Range(0, 2)] public int speed = 2;
+
+        [Header("Which organisms are present")]
+        [Tooltip("Untick one to watch the food web reorganise around the gap. " +
+                 "Unticking the tiger shark is the trophic-cascade demonstration.")]
+        public bool calcareousGreenAlga = true;
+        public bool fanAlga = true;
+        public bool lesserStarletCoral = true;
+        public bool parrotfish = true;
+        public bool longSpinedSeaUrchin = true;
+        public bool keyholeLimpet = true;
+        public bool brownSpinyLobster = true;
+        public bool commonOctopus = true;
+        public bool tigerShark = true;
+
+        [Header("Repeatability")]
+        [Tooltip("The same seed replays identically, so a problem can be reproduced.")]
+        public int seed = 12345;
+
+        LivingReefController _reef;
+
+        void Start()
+        {
+            if (!enableEcosystem) return;
+
+            // Guard against both this and the real bootstrap installing a reef.
+            if (FindFirstObjectByType<LivingReefController>() != null)
+            {
+                Debug.LogWarning("[LivingReefPreview] A Living Reef is already running; " +
+                                 "the preview will not add a second one.", this);
+                return;
+            }
+
+            var settings = new EcosystemSettings
+            {
+                enabled = true,
+                startingLife = startingLife,
+                temperatureC = temperatureC,
+                acidityPh = acidityPh,
+                speed = speed,
+            };
+            settings.Clamp();
+
+            settings.present[SpeciesLibrary.Halimeda]   = calcareousGreenAlga;
+            settings.present[SpeciesLibrary.Padina]     = fanAlga;
+            settings.present[SpeciesLibrary.Coral]      = lesserStarletCoral;
+            settings.present[SpeciesLibrary.Parrotfish] = parrotfish;
+            settings.present[SpeciesLibrary.Urchin]     = longSpinedSeaUrchin;
+            settings.present[SpeciesLibrary.Limpet]     = keyholeLimpet;
+            settings.present[SpeciesLibrary.Lobster]    = brownSpinyLobster;
+            settings.present[SpeciesLibrary.Octopus]    = commonOctopus;
+            settings.present[SpeciesLibrary.TigerShark] = tigerShark;
+
+            // Pinned to this object rather than to the camera, so a fixed preview
+            // camera looks across the reef instead of standing in the middle of it.
+            _reef = LivingReefController.Install(settings, seed, followViewer: false);
+            _reef.transform.position = transform.position;
+            Debug.Log("[LivingReefPreview] Reef running. Open the 'Reef' tab on the right " +
+                      "of the screen for the panel.");
+        }
+
+        // Convenience for testing from the inspector's context menu while playing.
+        [ContextMenu("Remove the tiger shark")]
+        void RemoveShark()
+        {
+            if (_reef == null) { Debug.LogWarning("Not playing."); return; }
+            _reef.SetSpeciesPresent(SpeciesLibrary.TigerShark, false);
+            Debug.Log("[LivingReefPreview] Tiger shark removed. Watch the urchins climb.");
+        }
+
+        [ContextMenu("Put every species back")]
+        void RestoreAll()
+        {
+            if (_reef == null) { Debug.LogWarning("Not playing."); return; }
+            _reef.RestoreAllSpecies();
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/LivingReefPreview.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/LivingReefPreview.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 639519d3690295d4297a7cc70f2102be

--- a/Assets/Scripts/LivingEcosystem/Memory.meta
+++ b/Assets/Scripts/LivingEcosystem/Memory.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bb5b44434b977ef4182ce8db371d44ed
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/LivingEcosystem/Memory/EcosystemReport.cs
+++ b/Assets/Scripts/LivingEcosystem/Memory/EcosystemReport.cs
@@ -1,0 +1,665 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using CreateEnv.Ecosystem.Genetics;
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem.Memory
+{
+    // The report a learner takes away with them (Design Document 7.3).
+    //
+    // The point of this is not the file. It is that the reef stops being a thing that
+    // happened on a phone and becomes evidence: what was set up, what was predicted,
+    // what actually occurred, and why.
+    //
+    // Kept to about two pages, and written the way a researcher writes for themselves
+    // — figures and short factual lines, not explanations. An earlier draft carried a
+    // paragraph of teaching prose under every chart and ran to five pages; a report
+    // nobody reads to the end has failed regardless of what is in it. What survives is
+    // what the reader cannot reconstruct on their own: the numbers, the shapes, the
+    // sequence of events, and the pedigree.
+    //
+    // Everything sits on PdfWriter's baseline grid, so line spacing is even from the
+    // first page to the last.
+    public static class EcosystemReport
+    {
+        // ── Entry points ─────────────────────────────────────────────────────
+
+        // Everything the report needs, gathered into one argument.
+        //
+        // The report takes this rather than the controller so it can be built without
+        // a running scene — which is what lets a test generate a real PDF on a laptop
+        // and check it, instead of the report only ever being seen on a phone.
+        public struct Source
+        {
+            public string environmentName;
+            public EcosystemSimulation sim;
+            public EcosystemHealth health;
+            public EcosystemSettings settings;
+            public OctopusPopulation octopuses;
+            public ReefChronicle chronicle;
+            public IReadOnlyList<Reason> reasons;
+        }
+
+        public static byte[] Build(Source source)
+        {
+            var pdf = new PdfWriter();
+            Compose(pdf, source);
+            return pdf.ToBytes();
+        }
+
+        // Dated, so a learner can keep several and see which is which — the file name
+        // is the only label a PDF has in a downloads list.
+        public static string FileNameFor(string environmentName) =>
+            "reef-" + Slug(environmentName) + "-" + DateTime.Now.ToString("yyyyMMdd-HHmm") + ".pdf";
+
+        static string Slug(string name)
+        {
+            if (string.IsNullOrEmpty(name)) return "reef";
+            var sb = new StringBuilder(name.Length);
+            foreach (char c in name)
+                sb.Append(char.IsLetterOrDigit(c) ? char.ToLowerInvariant(c) : '-');
+            return sb.ToString().Trim('-');
+        }
+
+        // ── Composition ──────────────────────────────────────────────────────
+
+        const float Line = PdfWriter.Line;
+
+        static void Compose(PdfWriter pdf, Source source)
+        {
+            var sim = source.sim;
+            var octopuses = source.octopuses;
+            var history = source.chronicle?.history;
+
+            Header(pdf, source.environmentName, sim, source.health);
+            Setup(pdf, source.settings, sim, source.health);
+            Populations(pdf, history, sim);
+            Pyramid(pdf, sim);
+            WhatHappened(pdf, source.chronicle?.journal, octopuses, source.reasons);
+
+            if (octopuses != null && sim.IsPresent(SpeciesLibrary.Octopus))
+            {
+                FamilyTree(pdf, octopuses);
+                Genes(pdf, history, octopuses);
+            }
+
+            SpeciesList(pdf, sim);
+            Footnote(pdf);
+        }
+
+        // 1. Masthead ─────────────────────────────────────────────────────────
+        static void Header(PdfWriter pdf, string environmentName,
+                           EcosystemSimulation sim, EcosystemHealth health)
+        {
+            pdf.Space(Line);
+            pdf.TextAt(PdfWriter.Margin, pdf.Cursor, "REEF REPORT", 8f, true, PdfWriter.Faint);
+
+            pdf.Space(Line * 1.6f);
+            pdf.TextAt(PdfWriter.Margin, pdf.Cursor,
+                       string.IsNullOrEmpty(environmentName) ? "My Reef" : environmentName,
+                       18f, true, PdfWriter.Ink);
+
+            // The verdict, right-aligned on the same line as the title: a reader who
+            // gets no further than the top of the page still learns how it ended.
+            string verdict = EcosystemHealth.Describe(health.stage);
+            var colour = HealthColour(health.level);
+            float verdictWidth = PdfWriter.Measure(verdict, 9.5f, true) + 22f;
+            float verdictX = PdfWriter.PageWidth - PdfWriter.Margin - verdictWidth;
+
+            pdf.Rect(verdictX, pdf.Cursor - 4f, verdictWidth, 20f,
+                     Color.Lerp(Color.white, colour, 0.16f));
+            pdf.Rect(verdictX, pdf.Cursor - 4f, 3f, 20f, colour);
+            pdf.TextAt(verdictX + 11f, pdf.Cursor + 2f, verdict, 9.5f, true, PdfWriter.Ink);
+
+            pdf.Space(Line);
+            pdf.TextAt(PdfWriter.Margin, pdf.Cursor,
+                       "Day " + sim.day + "  ·  " + DateTime.Now.ToString("d MMMM yyyy"),
+                       9f, false, PdfWriter.Faint);
+            pdf.Space(6f);
+        }
+
+        static Color HealthColour(HealthLevel level) => level switch
+        {
+            HealthLevel.Green => new Color(0.20f, 0.65f, 0.35f),
+            HealthLevel.Amber => new Color(0.85f, 0.62f, 0.15f),
+            _                 => new Color(0.82f, 0.28f, 0.24f),
+        };
+
+        // 2. Setup and prediction ─────────────────────────────────────────────
+        static void Setup(PdfWriter pdf, EcosystemSettings settings,
+                          EcosystemSimulation sim, EcosystemHealth health)
+        {
+            pdf.Heading("Setup");
+
+            var included = new List<string>();
+            var excluded = new List<string>();
+            for (int i = 0; i < SpeciesLibrary.Count; i++)
+            {
+                var def = SpeciesLibrary.Get(i);
+                if (def == null) continue;
+                (sim.IsPresent(i) ? included : excluded).Add(def.commonName);
+            }
+
+            pdf.Field("Temperature", sim.temperatureC.ToString("0.#") + " °C");
+            pdf.Field("pH", sim.acidityPh.ToString("0.00"));
+            pdf.Field("Starting life",
+                      EcosystemSettings.StartingLifeOptions[
+                          Mathf.Clamp(settings != null ? settings.startingLife : 1, 0,
+                                      EcosystemSettings.StartingLifeOptions.Length - 1)]);
+            pdf.Field("Species present", included.Count + " of " + SpeciesLibrary.Count);
+
+            if (excluded.Count > 0)
+                pdf.Field("Left out", string.Join(", ", excluded));
+
+            // The prediction belongs with the setup: it was made at the same moment,
+            // and on its own it did not need a heading of its own.
+            if (settings != null && settings.predictionIndex >= 0)
+            {
+                int actual = EcosystemWarnings.OutcomeIndex(health, sim);
+                pdf.Field(settings.predictionIndex == actual ? "Prediction (correct)"
+                                                             : "Prediction (missed)",
+                          EcosystemWarnings.PredictionOptions[
+                              Mathf.Clamp(settings.predictionIndex, 0,
+                                          EcosystemWarnings.PredictionOptions.Length - 1)]);
+                pdf.Field("Outcome", EcosystemWarnings.PredictionOptions[
+                              Mathf.Clamp(actual, 0,
+                                          EcosystemWarnings.PredictionOptions.Length - 1)]);
+            }
+        }
+
+        // 3. Populations ──────────────────────────────────────────────────────
+        static void Populations(PdfWriter pdf, ReefHistory history, EcosystemSimulation sim)
+        {
+            pdf.Heading("Populations", keepWith: 8f * Line);
+
+            if (history == null || history.count < 2)
+            {
+                pdf.Paragraph("Too early for a chart — the reef has not run long enough yet.",
+                              9f, false, PdfWriter.Faint);
+                return;
+            }
+
+            // Animals only. Producer biomass runs orders of magnitude above a headcount,
+            // and on one pair of axes it flattens every animal onto the floor.
+            var series = new List<int>();
+            for (int i = 0; i < SpeciesLibrary.Count; i++)
+            {
+                var def = SpeciesLibrary.Get(i);
+                if (def == null || def.IsProducer || def.transient) continue;
+                if (!sim.IsPresent(i)) continue;
+                series.Add(i);
+            }
+
+            DrawSeriesChart(pdf, history, series, 9f * Line,
+                            (h, s, k) => h.AmountAt(s, k),
+                            k => SpeciesLibrary.NameOf(k),
+                            k => SpeciesLibrary.Get(k).tint,
+                            v => v.ToString("0.#"));
+
+            pdf.Space(Line * 0.5f);
+
+            foreach (int k in series)
+            {
+                var def = SpeciesLibrary.Get(k);
+                float first = history.AmountAt(0, k);
+                float last = history.AmountAt(history.count - 1, k);
+
+                string figure = Mathf.Abs(last - first) < 0.05f
+                    ? "steady at " + last.ToString("0.#")
+                    : first.ToString("0.#") + "  →  " + last.ToString("0.#") +
+                      "   (" + (last > first ? "+" : "") +
+                      Mathf.RoundToInt(history.ChangeOf(k) * 100f) + "%)";
+
+                pdf.Row(def.tint, def.commonName, figure);
+            }
+        }
+
+        // 4. Energy ───────────────────────────────────────────────────────────
+        static readonly TrophicLevel[] PyramidLevels =
+        {
+            TrophicLevel.TopPredator,
+            TrophicLevel.Hunter,
+            TrophicLevel.PlantEater,
+            TrophicLevel.Producer,
+        };
+
+        static void Pyramid(PdfWriter pdf, EcosystemSimulation sim)
+        {
+            // Heading and bars are one figure and never split across a page.
+            pdf.Heading("Energy", keepWith: 5f * Line);
+
+            float baseline = Mathf.Max(0.001f, sim.BiomassAtLevel(TrophicLevel.Producer));
+            float widest = PdfWriter.ContentWidth - 190f;
+
+            foreach (var level in PyramidLevels)
+            {
+                float biomass = sim.BiomassAtLevel(level);
+                float width = Mathf.Max(2f, Mathf.Clamp01(biomass / baseline) * widest);
+
+                pdf.Space(Line);
+                pdf.TextAt(PdfWriter.Margin, pdf.Cursor, LevelWord(level), 9f, false, PdfWriter.Ink);
+                pdf.Rect(PdfWriter.Margin + 110f, pdf.Cursor - 1f, width, 9f, LevelColour(level));
+                pdf.TextAt(PdfWriter.Margin + 116f + width, pdf.Cursor,
+                           biomass.ToString("0.#") + " kg", 8f, false, PdfWriter.Faint);
+            }
+        }
+
+        static string LevelWord(TrophicLevel level) => level switch
+        {
+            TrophicLevel.Producer   => "Seaweed and coral",
+            TrophicLevel.PlantEater => "Plant eaters",
+            TrophicLevel.Hunter     => "Hunters",
+            _                       => "Top predator",
+        };
+
+        // The pyramid band is a group; a species row needs the singular role.
+        static string RoleWord(TrophicLevel level) => level switch
+        {
+            TrophicLevel.Producer   => "producer",
+            TrophicLevel.PlantEater => "plant eater",
+            TrophicLevel.Hunter     => "hunter",
+            _                       => "top predator",
+        };
+
+        static Color LevelColour(TrophicLevel level) => level switch
+        {
+            TrophicLevel.Producer   => new Color(0.35f, 0.68f, 0.38f),
+            TrophicLevel.PlantEater => new Color(0.38f, 0.63f, 0.78f),
+            TrophicLevel.Hunter     => new Color(0.72f, 0.52f, 0.30f),
+            _                       => new Color(0.45f, 0.42f, 0.50f),
+        };
+
+        // 5. What happened ────────────────────────────────────────────────────
+
+        // The log is the one section that earns its length: it is the only record of
+        // the order things happened in, and order is what makes a cause a cause.
+        const int MaximumEvents = 12;
+
+        static void WhatHappened(PdfWriter pdf, ReefJournal journal,
+                                 OctopusPopulation octopuses, IReadOnlyList<Reason> reasons)
+        {
+            pdf.Heading("What happened");
+
+            var events = journal != null ? journal.Notable(0, MaximumEvents) : null;
+            if (events == null || events.Count == 0)
+            {
+                pdf.Paragraph("Nothing worth recording yet.", 9f, false, PdfWriter.Faint);
+            }
+            else
+            {
+                // Notable() ranks by importance so the right events survive the cut;
+                // reading them back in date order is what turns a list into a story.
+                events.Sort((a, b) => b.day.CompareTo(a.day));
+
+                foreach (var e in events)
+                {
+                    string line = ReefJournal.Describe(e, octopuses);
+                    if (string.IsNullOrEmpty(line)) continue;
+
+                    pdf.EnsureRoom(Line);
+                    pdf.Space(Line);
+                    pdf.TextAt(PdfWriter.Margin, pdf.Cursor, "Day " + e.day, 8.5f, false, PdfWriter.Faint);
+                    pdf.TextAt(PdfWriter.Margin + 46f, pdf.Cursor, line, 9f, false, PdfWriter.Ink);
+                }
+            }
+
+            // Why it is like this now, in the same words the Why panel uses on screen,
+            // so the report and the app can never tell a learner two different stories.
+            if (reasons != null && reasons.Count > 0)
+            {
+                pdf.Space(Line * 0.5f);
+                for (int i = 0; i < reasons.Count && i < 2; i++)
+                {
+                    pdf.EnsureRoom(Line * 3f);
+                    pdf.Space(Line * 0.5f);
+                    pdf.Paragraph(reasons[i].whatIsHappening, 9f, true);
+                    pdf.Paragraph(reasons[i].whyItIsHappening, 9f, false, PdfWriter.Faint);
+                }
+            }
+        }
+
+        // 6. Family tree ──────────────────────────────────────────────────────
+        struct TreeNode
+        {
+            public int id;
+            public string name;
+            public Genome genome;
+            public Sex sex;
+            public int generation;
+            public int motherId, fatherId;
+            public bool alive;
+            public CauseOfDeath cause;
+        }
+
+        const float BoxWidth = 108f;
+        const float BoxHeight = 3f * Line;
+
+        static void FamilyTree(PdfWriter pdf, OctopusPopulation octopuses)
+        {
+            pdf.Heading("Octopus pedigree", keepWith: 6f * Line);
+
+            pdf.Field("Hatched / died / alive",
+                      octopuses.TotalBorn + " / " + octopuses.TotalDied + " / " + octopuses.AliveCount);
+            pdf.Field("Generations", Mathf.Max(1, octopuses.HighestGeneration).ToString());
+            pdf.Field("Gene letters", "camouflage · body size · heat tolerance, capital = stronger copy");
+
+            // Everyone, living and dead, sorted into generations.
+            var rows = new Dictionary<int, List<TreeNode>>();
+            void Place(TreeNode node)
+            {
+                if (!rows.TryGetValue(node.generation, out var list))
+                    rows[node.generation] = list = new List<TreeNode>();
+                list.Add(node);
+            }
+
+            foreach (var a in octopuses.agents)
+            {
+                if (!a.IsAlive) continue;
+                Place(new TreeNode
+                {
+                    id = a.id, name = a.name, genome = a.genome, sex = a.sex,
+                    generation = a.generation, motherId = a.motherId, fatherId = a.fatherId,
+                    alive = true,
+                });
+            }
+            foreach (var r in octopuses.ancestors)
+            {
+                Place(new TreeNode
+                {
+                    id = r.id, name = r.Name, genome = r.genome, sex = r.Sex,
+                    generation = r.generation, motherId = r.motherId, fatherId = r.fatherId,
+                    alive = false, cause = r.Cause,
+                });
+            }
+
+            var generations = new List<int>(rows.Keys);
+            generations.Sort();
+            if (generations.Count == 0)
+            {
+                pdf.Paragraph("No octopuses have lived here yet.", 9f, false, PdfWriter.Faint);
+                return;
+            }
+
+            // A box's centre-top, so the next generation can draw a line up to it.
+            // Cleared when a generation lands on a new page: a line to a box on the
+            // previous sheet would run off this one.
+            var placed = new Dictionary<int, Vector2>();
+            int lastPage = pdf.PageCount;
+
+            int perRow = Mathf.Max(1, Mathf.FloorToInt(PdfWriter.ContentWidth / (BoxWidth + 8f)));
+
+            foreach (int gen in generations)
+            {
+                var row = rows[gen];
+
+                pdf.EnsureRoom(BoxHeight + 3f * Line);
+                if (pdf.PageCount != lastPage)
+                {
+                    placed.Clear();
+                    lastPage = pdf.PageCount;
+                }
+
+                pdf.Space(Line);
+                pdf.TextAt(PdfWriter.Margin, pdf.Cursor,
+                           gen == 0 ? "Founders" : "Generation " + gen, 8f, true, PdfWriter.Faint);
+
+                // A generation wider than the page wraps onto another line rather than
+                // being cut off. A pedigree with animals missing from it is not a
+                // pedigree, and it is the founders — the largest generation — that
+                // would lose members.
+                var newlyPlaced = new List<KeyValuePair<int, Vector2>>(row.Count);
+
+                for (int start = 0; start < row.Count; start += perRow)
+                {
+                    int shown = Mathf.Min(perRow, row.Count - start);
+
+                    if (start > 0) pdf.EnsureRoom(BoxHeight + Line);
+                    pdf.Space(BoxHeight + Line);
+                    float boxBottom = pdf.Cursor;
+
+                    float span = shown * BoxWidth + (shown - 1) * 8f;
+                    float startX = PdfWriter.Margin +
+                                   Mathf.Max(0f, (PdfWriter.ContentWidth - span) * 0.5f);
+
+                    for (int i = 0; i < shown; i++)
+                    {
+                        var node = row[start + i];
+                        float x = startX + i * (BoxWidth + 8f);
+                        DrawOctopusBox(pdf, node, x, boxBottom);
+
+                        var centreTop = new Vector2(x + BoxWidth * 0.5f, boxBottom + BoxHeight);
+                        newlyPlaced.Add(new KeyValuePair<int, Vector2>(node.id, centreTop));
+
+                        LinkToParent(pdf, placed, node.motherId, centreTop);
+                        LinkToParent(pdf, placed, node.fatherId, centreTop);
+                    }
+                }
+
+                // Added after the links are drawn, so a sibling in the same generation
+                // is never mistaken for a parent.
+                foreach (var entry in newlyPlaced) placed[entry.Key] = entry.Value;
+            }
+        }
+
+        static void LinkToParent(PdfWriter pdf, Dictionary<int, Vector2> placed,
+                                 int parentId, Vector2 childTop)
+        {
+            if (parentId < 0 || !placed.TryGetValue(parentId, out var parentTop)) return;
+
+            // The stored point is the parent's top; its box hangs BoxHeight below, and
+            // the line has to meet the bottom edge or it runs through the parent's text.
+            float parentBottom = parentTop.y - BoxHeight;
+            if (parentBottom <= childTop.y) return;
+
+            float mid = (childTop.y + parentBottom) * 0.5f;
+            pdf.Stroke(childTop.x, childTop.y, childTop.x, mid, PdfWriter.Rule, 0.6f);
+            pdf.Stroke(childTop.x, mid, parentTop.x, mid, PdfWriter.Rule, 0.6f);
+            pdf.Stroke(parentTop.x, mid, parentTop.x, parentBottom, PdfWriter.Rule, 0.6f);
+        }
+
+        static void DrawOctopusBox(PdfWriter pdf, TreeNode node, float x, float y)
+        {
+            pdf.Rect(x, y, BoxWidth, BoxHeight,
+                     node.alive ? new Color(0.93f, 0.97f, 0.94f) : new Color(0.95f, 0.95f, 0.96f));
+            pdf.Rect(x, y, 3f, BoxHeight,
+                     node.alive ? PdfWriter.Accent : new Color(0.72f, 0.75f, 0.78f));
+
+            pdf.TextAt(x + 8f, y + BoxHeight - 12f, Fit(node.name, 8.5f, true), 8.5f, true, PdfWriter.Ink);
+
+            string subtitle = node.sex == Sex.Female ? "female" : "male";
+            if (!node.alive && node.cause != CauseOfDeath.StillAlive)
+                subtitle += ", " + OctopusAgent.CauseWord(node.cause);
+            pdf.TextAt(x + 8f, y + BoxHeight - 22f, Fit(subtitle, 7f, false), 7f, false, PdfWriter.Faint);
+
+            var sb = new StringBuilder();
+            for (int g = 0; g < Genome.GeneCount; g++)
+            {
+                if (g > 0) sb.Append(' ');
+                sb.Append(node.genome.Notation((GeneId)g));
+            }
+            pdf.TextAt(x + 8f, y + 7f, sb.ToString(), 7.5f, false, PdfWriter.Ink);
+        }
+
+        // Trims to the width of a box rather than letting it overrun into its neighbour.
+        static string Fit(string text, float size, bool bold)
+        {
+            if (string.IsNullOrEmpty(text)) return "";
+            while (text.Length > 3 && PdfWriter.Measure(text, size, bold) > BoxWidth - 14f)
+                text = text.Substring(0, text.Length - 1);
+            return text;
+        }
+
+        // 7. Genes ────────────────────────────────────────────────────────────
+        static void Genes(PdfWriter pdf, ReefHistory history, OctopusPopulation octopuses)
+        {
+            pdf.Heading("Gene frequencies", keepWith: 6f * Line);
+
+            if (history != null && history.count >= 2)
+            {
+                DrawSeriesChart(pdf, history, new List<int> { 0, 1, 2 }, 7f * Line,
+                                (h, s, k) => h.GeneAt(s, (GeneId)k) * 100f,
+                                k => Genome.NameOf((GeneId)k),
+                                k => GeneColour((GeneId)k),
+                                v => v.ToString("0") + "%");
+                pdf.Space(Line * 0.5f);
+            }
+
+            for (int g = 0; g < Genome.GeneCount; g++)
+            {
+                var gene = (GeneId)g;
+                float share = octopuses.AlleleFrequency(gene);
+                pdf.Row(GeneColour(gene), Genome.NameOf(gene),
+                        (share * 100f).ToString("0") + "%   " + Fixation(share), 9f, 120f);
+            }
+        }
+
+        // With five animals a gene can vanish through nothing but luck. Naming which of
+        // the two happened is the whole lesson of drift against selection, and it is the
+        // one thing a learner cannot read off the chart for themselves.
+        static string Fixation(float share)
+        {
+            if (share >= 0.999f) return "fixed — the alternative is lost";
+            if (share <= 0.001f) return "lost from the population";
+            if (share >= 0.85f)  return "nearly fixed";
+            if (share <= 0.15f)  return "nearly lost";
+            return "both versions still present";
+        }
+
+        static Color GeneColour(GeneId gene) => gene switch
+        {
+            GeneId.Camouflage => new Color(0.30f, 0.55f, 0.72f),
+            GeneId.BodySize   => new Color(0.76f, 0.48f, 0.28f),
+            _                 => new Color(0.68f, 0.33f, 0.55f),
+        };
+
+        // 8. Species ──────────────────────────────────────────────────────────
+
+        // One line each: what it is called, what it is, and how it is doing in the
+        // wild. The long natural-history notes live in the app, where a learner can
+        // read them when they are curious about one animal rather than all nine.
+        static void SpeciesList(PdfWriter pdf, EcosystemSimulation sim)
+        {
+            pdf.Heading("Species");
+
+            for (int i = 0; i < SpeciesLibrary.Count; i++)
+            {
+                if (!sim.IsPresent(i)) continue;
+                var def = SpeciesLibrary.Get(i);
+                if (def == null) continue;
+
+                pdf.EnsureRoom(Line);
+                pdf.Space(Line);
+                pdf.Rect(PdfWriter.Margin, pdf.Cursor + 1f, 6f, 6f, def.tint);
+                pdf.TextAt(PdfWriter.Margin + 13f, pdf.Cursor, def.commonName, 9f, false, PdfWriter.Ink);
+                pdf.TextAt(PdfWriter.Margin + 130f, pdf.Cursor, def.scientificName, 8.5f, false, PdfWriter.Faint);
+
+                string status = string.IsNullOrEmpty(def.iucnStatus) ? "" : def.iucnStatus;
+                pdf.TextAt(PdfWriter.Margin + 290f, pdf.Cursor,
+                           RoleWord(def.level) + (status.Length > 0 ? "  ·  " + status : ""),
+                           8.5f, false, PdfWriter.Faint);
+            }
+        }
+
+        // 9. Footnote ─────────────────────────────────────────────────────────
+        static void Footnote(PdfWriter pdf)
+        {
+            pdf.Space(Line * 0.5f);
+            pdf.EnsureRoom(Line * 3f);
+            pdf.Stroke(PdfWriter.Margin, pdf.Cursor, PdfWriter.PageWidth - PdfWriter.Margin,
+                       pdf.Cursor, PdfWriter.Rule, 0.6f);
+            pdf.Space(Line * 0.5f);
+
+            // Short, but not dropped. A model that does not say where it stops being
+            // true is teaching something false.
+            pdf.Paragraph("A teaching model of one patch of Cabo Verde reef, from published rates: faster " +
+                          "than life, far fewer animals, the rest of the ocean held still. Broods are two " +
+                          "to four rather than thousands, the shark visits rather than lives here, and " +
+                          "some species are given at genus level.",
+                          8f, false, PdfWriter.Faint);
+        }
+
+        // ── Charting ─────────────────────────────────────────────────────────
+
+        // One routine draws both the population lines and the gene lines. They differ
+        // only in what a series means, so they share axes, gridlines and legend — and a
+        // reader who has learned to read one has learned to read the other.
+        static void DrawSeriesChart(PdfWriter pdf, ReefHistory history, List<int> series,
+                                    float height,
+                                    Func<ReefHistory, int, int, float> valueAt,
+                                    Func<int, string> nameOf,
+                                    Func<int, Color> colourOf,
+                                    Func<float, string> formatValue)
+        {
+            if (series.Count == 0 || history.count < 2) return;
+
+            float legendRows = Mathf.Ceil(series.Count / 3f);
+            pdf.EnsureRoom(height + (legendRows + 2f) * Line);
+
+            pdf.Space(height);
+            float bottom = pdf.Cursor;
+            float left = PdfWriter.Margin + 30f;
+            float right = PdfWriter.PageWidth - PdfWriter.Margin;
+            float plotWidth = right - left;
+
+            // The tallest value across every series, rounded up so the top gridline is a
+            // number a reader can hold in their head.
+            float peak = 0f;
+            foreach (int k in series)
+                for (int s = 0; s < history.count; s++)
+                    peak = Mathf.Max(peak, valueAt(history, s, k));
+            peak = NiceCeiling(peak);
+
+            for (int g = 0; g <= 2; g++)
+            {
+                float y = bottom + height * g / 2f;
+                pdf.Stroke(left, y, right, y, PdfWriter.Rule, 0.4f);
+                pdf.TextAt(PdfWriter.Margin, y - 2.5f, formatValue(peak * g / 2f),
+                           7f, false, PdfWriter.Faint);
+            }
+
+            // Day labels at each end. Two are enough — the chart is about shape.
+            pdf.TextAt(left, bottom - 10f, "day " + history.DayAt(0), 7f, false, PdfWriter.Faint);
+            string lastLabel = "day " + history.DayAt(history.count - 1);
+            pdf.TextAt(right - PdfWriter.Measure(lastLabel, 7f, false), bottom - 10f,
+                       lastLabel, 7f, false, PdfWriter.Faint);
+
+            foreach (int k in series)
+            {
+                var colour = colourOf(k);
+                float previousX = 0f, previousY = 0f;
+
+                for (int s = 0; s < history.count; s++)
+                {
+                    float x = left + plotWidth * s / (history.count - 1f);
+                    float y = bottom + Mathf.Clamp01(valueAt(history, s, k) / peak) * height;
+                    if (s > 0) pdf.Stroke(previousX, previousY, x, y, colour, 1.1f);
+                    previousX = x;
+                    previousY = y;
+                }
+            }
+
+            // Legend, three across, on the grid like everything else.
+            pdf.Space(Line * 1.5f);
+            for (int i = 0; i < series.Count; i++)
+            {
+                int column = i % 3;
+                if (column == 0 && i > 0) pdf.Space(Line);
+
+                float x = PdfWriter.Margin + column * (PdfWriter.ContentWidth / 3f);
+                pdf.Rect(x, pdf.Cursor + 1f, 6f, 6f, colourOf(series[i]));
+                pdf.TextAt(x + 11f, pdf.Cursor, nameOf(series[i]), 8f, false, PdfWriter.Ink);
+            }
+        }
+
+        // Rounds an axis maximum up to 1, 2 or 5 times a power of ten.
+        static float NiceCeiling(float value)
+        {
+            if (value <= 0f) return 1f;
+            float magnitude = Mathf.Pow(10f, Mathf.Floor(Mathf.Log10(value)));
+            float normalised = value / magnitude;
+            float step = normalised <= 1f ? 1f : normalised <= 2f ? 2f : normalised <= 5f ? 5f : 10f;
+            return step * magnitude;
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Memory/EcosystemReport.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Memory/EcosystemReport.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8cc620cc2fbf15c42a1ce1be8a42ced0

--- a/Assets/Scripts/LivingEcosystem/Memory/PdfWriter.cs
+++ b/Assets/Scripts/LivingEcosystem/Memory/PdfWriter.cs
@@ -1,0 +1,320 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem.Memory
+{
+    // A small PDF writer.
+    //
+    // The design document describes composing the report as HTML and rendering it to
+    // PDF on the device. Unity has no HTML renderer, and the platform ones live
+    // behind a native plugin that can only be exercised on a phone. Since almost
+    // every real bug in this feature was caught by running things headlessly, the
+    // report is built here instead: no plugin, no dependency, it runs in the Editor,
+    // and a test can generate a real file and check it.
+    //
+    // Only what a lab report needs — text, wrapped paragraphs, rules, filled
+    // rectangles and lines. Type is Helvetica, one of the fourteen fonts every PDF
+    // reader is required to have, so nothing is embedded and the file stays tiny.
+    public class PdfWriter
+    {
+        // A4 in points.
+        public const float PageWidth = 595f;
+        public const float PageHeight = 842f;
+        public const float Margin = 48f;
+        public const float ContentWidth = PageWidth - Margin * 2f;
+
+        // One line of the baseline grid.
+        //
+        // Every line of text and every gap is a whole number of these, whatever the
+        // font size. Mixed leading is what makes a document look assembled out of
+        // fragments — the eye reads uneven spacing as unrelated blocks even when the
+        // words say otherwise.
+        public const float Line = 13f;
+
+        readonly List<StringBuilder> _pages = new List<StringBuilder>();
+        StringBuilder _page;
+
+        // The pen, in PDF coordinates: y counts up from the bottom of the page.
+        public float Cursor { get; private set; }
+
+        public int PageCount => _pages.Count;
+
+        public PdfWriter()
+        {
+            NewPage();
+        }
+
+        public void NewPage()
+        {
+            _page = new StringBuilder(4096);
+            _pages.Add(_page);
+            Cursor = PageHeight - Margin;
+        }
+
+        // Starts a new page when the next block would not fit on this one.
+        public void EnsureRoom(float height)
+        {
+            if (Cursor - height < Margin) NewPage();
+        }
+
+        public void Space(float points) => Cursor -= points;
+
+        // ── Drawing ──────────────────────────────────────────────────────────
+
+        public void SetFill(Color c) =>
+            _page.Append(F(c.r)).Append(' ').Append(F(c.g)).Append(' ').Append(F(c.b)).Append(" rg\n");
+
+        public void SetStroke(Color c) =>
+            _page.Append(F(c.r)).Append(' ').Append(F(c.g)).Append(' ').Append(F(c.b)).Append(" RG\n");
+
+        public void Rect(float x, float y, float w, float h, Color fill)
+        {
+            SetFill(fill);
+            _page.Append(F(x)).Append(' ').Append(F(y)).Append(' ')
+                 .Append(F(w)).Append(' ').Append(F(h)).Append(" re f\n");
+        }
+
+        public void Stroke(float x1, float y1, float x2, float y2, Color colour, float width = 0.8f)
+        {
+            SetStroke(colour);
+            _page.Append(F(width)).Append(" w\n")
+                 .Append(F(x1)).Append(' ').Append(F(y1)).Append(" m ")
+                 .Append(F(x2)).Append(' ').Append(F(y2)).Append(" l S\n");
+        }
+
+        // One line of text at an exact position. Does not move the cursor.
+        public void TextAt(float x, float y, string text, float size, bool bold, Color colour)
+        {
+            if (string.IsNullOrEmpty(text)) return;
+            SetFill(colour);
+            _page.Append("BT /").Append(bold ? "F2" : "F1").Append(' ').Append(F(size))
+                 .Append(" Tf ").Append(F(x)).Append(' ').Append(F(y)).Append(" Td (")
+                 .Append(Escape(text)).Append(") Tj ET\n");
+        }
+
+        // A heading, with the space above and below it that makes a document
+        // readable rather than a wall.
+        //
+        // `keepWith` is room reserved for whatever follows. A heading stranded at the
+        // foot of a page, with its section starting overleaf, reads as though the
+        // section is missing — so a heading only lands here if something can land
+        // under it.
+        public void Heading(string text, float size = 12.5f, float keepWith = 3f * Line)
+        {
+            EnsureRoom(Line * 2.5f + keepWith);
+            Cursor -= Line * 1.5f;
+            TextAt(Margin, Cursor, text, size, true, Ink);
+            Cursor -= 6f;
+            Stroke(Margin, Cursor, PageWidth - Margin, Cursor, Rule, 0.6f);
+            Cursor -= Line - 6f;
+        }
+
+        // A wrapped paragraph, one grid line per line of text. Returns the height used.
+        public float Paragraph(string text, float size = 9f, bool bold = false,
+                               Color? colour = null, float indent = 0f)
+        {
+            if (string.IsNullOrEmpty(text)) return 0f;
+
+            var lines = Wrap(text, size, bold, ContentWidth - indent);
+            float used = 0f;
+
+            foreach (var line in lines)
+            {
+                EnsureRoom(Line);
+                Cursor -= Line;
+                TextAt(Margin + indent, Cursor, line, size, bold, colour ?? Ink);
+                used += Line;
+            }
+            return used;
+        }
+
+        // A label on the left and a value beside it, as a setup sheet reads.
+        public void Field(string label, string value, float size = 9f, float valueAt = 132f)
+        {
+            EnsureRoom(Line);
+            Cursor -= Line;
+            TextAt(Margin, Cursor, label, size, false, Faint);
+            TextAt(Margin + valueAt, Cursor, value, size, false, Ink);
+        }
+
+        // One row of a list: a colour chip, a name, and a figure further along.
+        public void Row(Color chip, string name, string value, float size = 9f,
+                        float valueAt = 190f)
+        {
+            EnsureRoom(Line);
+            Cursor -= Line;
+            Rect(Margin, Cursor + 1f, 6f, 6f, chip);
+            TextAt(Margin + 13f, Cursor, name, size, false, Ink);
+            if (!string.IsNullOrEmpty(value))
+                TextAt(Margin + valueAt, Cursor, value, size, false, Faint);
+        }
+
+        // ── Text measurement ─────────────────────────────────────────────────
+
+        // Helvetica advance widths, thousandths of an em, for printable ASCII.
+        // Wrapping only needs to be close, but close is much better than assuming
+        // every glyph is the same width, which makes ragged text look broken.
+        static readonly short[] Widths =
+        {
+            278,278,355,556,556,889,667,191,333,333,389,584,278,333,278,278,          // 32-47
+            556,556,556,556,556,556,556,556,556,556,278,278,584,584,584,556,          // 48-63
+            1015,667,667,722,722,667,611,778,722,278,500,667,556,833,722,778,         // 64-79
+            667,778,722,667,611,722,667,944,667,667,611,278,278,278,469,556,          // 80-95
+            333,556,556,500,556,556,278,556,556,222,222,500,222,833,556,556,          // 96-111
+            556,556,333,500,278,556,500,722,500,500,500,334,260,334,584,              // 112-126
+        };
+
+        public static float Measure(string text, float size, bool bold)
+        {
+            if (string.IsNullOrEmpty(text)) return 0f;
+            int units = 0;
+            foreach (char c in text)
+            {
+                int i = c - 32;
+                units += (i >= 0 && i < Widths.Length) ? Widths[i] : 556;
+            }
+            // Bold Helvetica is a little wider; near enough for line breaking.
+            return units / 1000f * size * (bold ? 1.06f : 1f);
+        }
+
+        public static List<string> Wrap(string text, float size, bool bold, float width)
+        {
+            var lines = new List<string>();
+            foreach (var paragraph in text.Split('\n'))
+            {
+                if (paragraph.Length == 0) { lines.Add(""); continue; }
+
+                var line = new StringBuilder();
+                foreach (var word in paragraph.Split(' '))
+                {
+                    if (word.Length == 0) continue;
+                    string candidate = line.Length == 0 ? word : line + " " + word;
+                    if (Measure(candidate, size, bold) <= width || line.Length == 0)
+                    {
+                        if (line.Length > 0) line.Append(' ');
+                        line.Append(word);
+                    }
+                    else
+                    {
+                        lines.Add(line.ToString());
+                        line.Clear();
+                        line.Append(word);
+                    }
+                }
+                lines.Add(line.ToString());
+            }
+            return lines;
+        }
+
+        // ── Palette ──────────────────────────────────────────────────────────
+        public static readonly Color Ink = new Color(0.11f, 0.14f, 0.17f);
+        public static readonly Color Faint = new Color(0.42f, 0.48f, 0.54f);
+        public static readonly Color Rule = new Color(0.80f, 0.84f, 0.87f);
+        public static readonly Color Accent = new Color(0.17f, 0.66f, 0.29f);
+
+        // ── Output ───────────────────────────────────────────────────────────
+
+        public byte[] ToBytes()
+        {
+            var pdf = new StringBuilder(16384);
+            var offsets = new List<int>();
+
+            void Obj(int id, string body)
+            {
+                offsets.Add(pdf.Length);
+                pdf.Append(id).Append(" 0 obj\n").Append(body).Append("\nendobj\n");
+            }
+
+            pdf.Append("%PDF-1.4\n");
+
+            int pageCount = _pages.Count;
+            int firstPageId = 4;
+            int firstContentId = firstPageId + pageCount;
+            int fontRegularId = firstContentId + pageCount;
+            int fontBoldId = fontRegularId + 1;
+
+            // 1 catalogue, 2 page tree, 3 unused placeholder kept so ids line up
+            Obj(1, "<< /Type /Catalog /Pages 2 0 R >>");
+
+            var kids = new StringBuilder();
+            for (int i = 0; i < pageCount; i++) kids.Append(firstPageId + i).Append(" 0 R ");
+            Obj(2, $"<< /Type /Pages /Kids [{kids.ToString().Trim()}] /Count {pageCount} >>");
+            Obj(3, "<< >>");
+
+            for (int i = 0; i < pageCount; i++)
+            {
+                Obj(firstPageId + i,
+                    $"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 {F(PageWidth)} {F(PageHeight)}] " +
+                    $"/Resources << /Font << /F1 {fontRegularId} 0 R /F2 {fontBoldId} 0 R >> >> " +
+                    $"/Contents {firstContentId + i} 0 R >>");
+            }
+
+            for (int i = 0; i < pageCount; i++)
+            {
+                string content = _pages[i].ToString();
+                Obj(firstContentId + i,
+                    $"<< /Length {Encoding.ASCII.GetByteCount(content)} >>\nstream\n{content}endstream");
+            }
+
+            Obj(fontRegularId, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>");
+            Obj(fontBoldId, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>");
+
+            int xrefAt = pdf.Length;
+            int total = offsets.Count + 1;
+            pdf.Append("xref\n0 ").Append(total).Append('\n');
+            pdf.Append("0000000000 65535 f \n");
+            foreach (int offset in offsets)
+                pdf.Append(offset.ToString("D10")).Append(" 00000 n \n");
+
+            pdf.Append("trailer\n<< /Size ").Append(total).Append(" /Root 1 0 R >>\nstartxref\n")
+               .Append(xrefAt).Append("\n%%EOF\n");
+
+            // Latin-1 keeps byte offsets equal to character offsets, which is what the
+            // cross-reference table above assumes.
+            return Encoding.GetEncoding(28591).GetBytes(pdf.ToString());
+        }
+
+        static string F(float v) => v.ToString("0.###", CultureInfo.InvariantCulture);
+
+        // Text is a PDF literal string; brackets and backslashes end it early.
+        // Anything outside Latin-1 is transliterated rather than dropped, so a stray
+        // dash or quotation mark cannot corrupt the file.
+        static string Escape(string text)
+        {
+            var sb = new StringBuilder(text.Length + 8);
+            foreach (char raw in text)
+            {
+                // Characters with no Latin-1 equivalent are spelled out rather than
+                // dropped. An arrow becoming a question mark is not a missing glyph a
+                // reader shrugs off — it turns "13 → 6" into "13 ? 6".
+                switch (raw)
+                {
+                    case '→': sb.Append("->");  continue;
+                    case '←': sb.Append("<-");  continue;
+                    case '…': sb.Append("..."); continue;
+                    case '≈': sb.Append("~");   continue;
+                    case '≤': sb.Append("<=");  continue;
+                    case '≥': sb.Append(">=");  continue;
+                }
+
+                char c = raw switch
+                {
+                    '—' or '–' => '-',
+                    '‘' or '’' => '\'',
+                    '“' or '”' => '"',
+                    '•' => '·',
+                    ' ' => ' ',
+                    _ => raw,
+                };
+
+                if (c == '(' || c == ')' || c == '\\') sb.Append('\\').Append(c);
+                else if (c < 32 || c > 255) sb.Append('?');
+                else sb.Append(c);
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Memory/PdfWriter.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Memory/PdfWriter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 69830b8560345e745a6fa7269e1b5d2b

--- a/Assets/Scripts/LivingEcosystem/Memory/ReefChronicle.cs
+++ b/Assets/Scripts/LivingEcosystem/Memory/ReefChronicle.cs
@@ -1,0 +1,124 @@
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem.Memory
+{
+    // Watches the reef and writes down what happens.
+    //
+    // The simulation knows its numbers but not which of their changes were worth
+    // remembering. This turns a running state into a record: it samples the history
+    // on a fixed cadence, and it notices the handful of transitions a learner would
+    // describe out loud — a species removed, the coral bleaching, a population
+    // crashing, the reef going barren.
+    //
+    // Deliberately edge-triggered. Recording "the coral is bleached" every day would
+    // fill the twenty-entry journal in under a month and bury everything else.
+    public class ReefChronicle
+    {
+        public readonly ReefHistory history = new ReefHistory();
+        public readonly ReefJournal journal = new ReefJournal();
+
+        // Last-seen state, so only changes are written down.
+        readonly bool[] _wasPresent = new bool[SpeciesLibrary.Count];
+        readonly float[] _lastNoted = new float[SpeciesLibrary.Count];
+        bool _wasBleached;
+        CollapseStage _lastStage = CollapseStage.Healthy;
+        bool _started;
+
+        // A population has to move by this much since it was last remarked upon
+        // before it is worth remarking upon again.
+        const float NotableChange = 0.45f;
+
+        public void Begin(EcosystemSimulation sim, EcosystemHealth health,
+                          Genetics.OctopusPopulation octopuses)
+        {
+            for (int i = 0; i < SpeciesLibrary.Count; i++)
+            {
+                _wasPresent[i] = sim.IsPresent(i);
+                _lastNoted[i] = sim.DisplayAmount(i);
+            }
+            _wasBleached = AnyBleached(sim);
+            _lastStage = health.stage;
+            _started = true;
+
+            if (history.IsEmpty) history.Sample(sim, health, octopuses);
+        }
+
+        // Called once per simulated day, after the simulation and the agents.
+        public void Observe(EcosystemSimulation sim, EcosystemHealth health,
+                            Genetics.OctopusPopulation octopuses)
+        {
+            if (!_started) Begin(sim, health, octopuses);
+
+            history.MaybeSample(sim, health, octopuses);
+
+            for (int i = 0; i < SpeciesLibrary.Count; i++)
+            {
+                bool present = sim.IsPresent(i);
+                if (present != _wasPresent[i])
+                {
+                    journal.Add(present ? ReefEventKind.SpeciesReturned
+                                        : ReefEventKind.SpeciesRemoved, sim.day, i);
+                    _wasPresent[i] = present;
+                    _lastNoted[i] = sim.DisplayAmount(i);
+                    continue;
+                }
+                if (!present) continue;
+
+                // The octopuses report their own births and deaths individually, so a
+                // headcount change there would say the same thing twice.
+                if (i == SpeciesLibrary.Octopus) continue;
+
+                float now = sim.DisplayAmount(i);
+                float was = _lastNoted[i];
+                if (was < 0.5f) { _lastNoted[i] = now; continue; }
+
+                float change = (now - was) / was;
+                if (change <= -NotableChange)
+                {
+                    journal.Add(ReefEventKind.PopulationCrashed, sim.day, i,
+                                Mathf.RoundToInt(change * 100f));
+                    _lastNoted[i] = now;
+                }
+                else if (change >= NotableChange * 1.6f)
+                {
+                    journal.Add(ReefEventKind.PopulationBoomed, sim.day, i,
+                                Mathf.RoundToInt(change * 100f));
+                    _lastNoted[i] = now;
+                }
+            }
+
+            bool bleached = AnyBleached(sim);
+            if (bleached != _wasBleached)
+            {
+                journal.Add(bleached ? ReefEventKind.CoralBleached
+                                     : ReefEventKind.CoralRecovered, sim.day, SpeciesLibrary.Coral);
+                _wasBleached = bleached;
+            }
+
+            if (health.stage != _lastStage)
+            {
+                if (health.stage == CollapseStage.Barren)
+                    journal.Add(ReefEventKind.WentBarren, sim.day);
+                else if (_lastStage >= CollapseStage.Collapse && health.stage <= CollapseStage.Overgrazing)
+                    journal.Add(ReefEventKind.Recovering, sim.day);
+                _lastStage = health.stage;
+            }
+        }
+
+        public void Reset()
+        {
+            history.Clear();
+            journal.Clear();
+            _started = false;
+            _wasBleached = false;
+            _lastStage = CollapseStage.Healthy;
+        }
+
+        static bool AnyBleached(EcosystemSimulation sim)
+        {
+            for (int i = 0; i < SpeciesLibrary.Count; i++)
+                if (sim.IsPresent(i) && sim.pools[i].bleached) return true;
+            return false;
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Memory/ReefChronicle.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Memory/ReefChronicle.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2ab8d609914395740acadd7ee35aba95

--- a/Assets/Scripts/LivingEcosystem/Memory/ReefHistory.cs
+++ b/Assets/Scripts/LivingEcosystem/Memory/ReefHistory.cs
@@ -1,0 +1,158 @@
+using System;
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem.Memory
+{
+    // What the reef has been doing, kept as a rolling record.
+    //
+    // Feeds the charts in the report and the "what changed while you were away"
+    // comparison. Stored as one byte per figure rather than as numbers, because the
+    // save file has a 4 KB budget and a hundred days of nine species written as JSON
+    // floats is six kilobytes on its own. A byte gives 1/255 resolution, which is far
+    // finer than a chart drawn a few hundred pixels wide can show.
+    [Serializable]
+    public class ReefHistory
+    {
+        // A sample every few days rather than daily: three hundred days of history in
+        // sixty samples, which is more than a session will ever produce and still
+        // under a kilobyte.
+        public const int DaysPerSample = 5;
+        public const int Capacity = 60;
+
+        // Per sample: nine species, three gene frequencies, one health level.
+        public const int Stride = SpeciesLibrary.Count + 3 + 1;
+
+        public byte[] samples = new byte[Capacity * Stride];
+        public int count;          // how many samples are filled
+        public int firstDay;       // simulated day of sample 0
+        public int lastSampledDay = int.MinValue;
+
+        public bool IsEmpty => count == 0;
+
+        public void Clear()
+        {
+            Array.Clear(samples, 0, samples.Length);
+            count = 0;
+            firstDay = 0;
+            lastSampledDay = int.MinValue;
+        }
+
+        // The largest value a species is ever likely to show, so its byte spans a
+        // useful range instead of hugging zero.
+        public static float ScaleOf(int species)
+        {
+            var def = SpeciesLibrary.Get(species);
+            if (def == null) return 1f;
+            return def.IsProducer ? Mathf.Max(1f, def.baseCapacity)
+                                  : Mathf.Max(1f, def.ceiling);
+        }
+
+        public void MaybeSample(EcosystemSimulation sim, EcosystemHealth health,
+                                Genetics.OctopusPopulation octopuses)
+        {
+            if (sim.day - lastSampledDay < DaysPerSample) return;
+            Sample(sim, health, octopuses);
+        }
+
+        public void Sample(EcosystemSimulation sim, EcosystemHealth health,
+                           Genetics.OctopusPopulation octopuses)
+        {
+            lastSampledDay = sim.day;
+
+            // Full: drop the oldest sample and shuffle down. Sixty entries of thirteen
+            // bytes is a memcpy of under a kilobyte, a few times a minute at most.
+            if (count >= Capacity)
+            {
+                Array.Copy(samples, Stride, samples, 0, (Capacity - 1) * Stride);
+                count = Capacity - 1;
+                firstDay += DaysPerSample;
+            }
+            else if (count == 0)
+            {
+                firstDay = sim.day;
+            }
+
+            int at = count * Stride;
+            for (int i = 0; i < SpeciesLibrary.Count; i++)
+                samples[at + i] = Quantise(sim.DisplayAmount(i) / ScaleOf(i));
+
+            int g = at + SpeciesLibrary.Count;
+            if (octopuses != null)
+            {
+                samples[g + 0] = Quantise(octopuses.AlleleFrequency(Genetics.GeneId.Camouflage));
+                samples[g + 1] = Quantise(octopuses.AlleleFrequency(Genetics.GeneId.BodySize));
+                samples[g + 2] = Quantise(octopuses.AlleleFrequency(Genetics.GeneId.HeatTolerance));
+            }
+
+            samples[at + Stride - 1] = (byte)Mathf.Clamp((int)health.level, 0, 2);
+            count++;
+        }
+
+        static byte Quantise(float unit) => (byte)Mathf.Clamp(Mathf.RoundToInt(unit * 255f), 0, 255);
+
+        // ── Reading back ─────────────────────────────────────────────────────
+
+        public int DayAt(int sample) => firstDay + sample * DaysPerSample;
+
+        // A species' amount at a sample, back in its own units.
+        public float AmountAt(int sample, int species)
+        {
+            if (sample < 0 || sample >= count) return 0f;
+            return samples[sample * Stride + species] / 255f * ScaleOf(species);
+        }
+
+        // A gene's frequency at a sample, 0..1.
+        public float GeneAt(int sample, Genetics.GeneId gene)
+        {
+            if (sample < 0 || sample >= count) return 0f;
+            return samples[sample * Stride + SpeciesLibrary.Count + (int)gene] / 255f;
+        }
+
+        public HealthLevel HealthAt(int sample)
+        {
+            if (sample < 0 || sample >= count) return HealthLevel.Green;
+            return (HealthLevel)samples[sample * Stride + Stride - 1];
+        }
+
+        // How much a species has changed across the whole record, as a fraction.
+        public float ChangeOf(int species)
+        {
+            if (count < 2) return 0f;
+            float first = AmountAt(0, species);
+            float last = AmountAt(count - 1, species);
+            if (first < 0.01f) return last > 0.01f ? 1f : 0f;
+            return (last - first) / first;
+        }
+
+        // ── Persistence ──────────────────────────────────────────────────────
+
+        public string Pack()
+        {
+            if (count == 0) return "";
+            var used = new byte[count * Stride];
+            Array.Copy(samples, used, used.Length);
+            return Convert.ToBase64String(used);
+        }
+
+        public void Unpack(string packed, int firstDayValue, int lastDay)
+        {
+            Clear();
+            if (string.IsNullOrEmpty(packed)) return;
+
+            try
+            {
+                var bytes = Convert.FromBase64String(packed);
+                int samplesIn = Mathf.Min(Capacity, bytes.Length / Stride);
+                Array.Copy(bytes, samples, samplesIn * Stride);
+                count = samplesIn;
+                firstDay = firstDayValue;
+                lastSampledDay = lastDay;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[ReefHistory] Could not read the saved history: {e.Message}");
+                Clear();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Memory/ReefHistory.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Memory/ReefHistory.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4715c9ea42034b94082d577d61ff2bc5

--- a/Assets/Scripts/LivingEcosystem/Memory/ReefJournal.cs
+++ b/Assets/Scripts/LivingEcosystem/Memory/ReefJournal.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem.Memory
+{
+    // What kind of thing happened. Stored as a code rather than a sentence.
+    //
+    // The app already ships in English and German, and a saved sentence is saved in
+    // whatever language it was generated in. Keeping the code and its subject means
+    // the wording is chosen when it is shown, so a reef saved in one language reads
+    // correctly in the other — and it costs a few bytes instead of sixty.
+    public enum ReefEventKind : byte
+    {
+        None = 0,
+
+        // Ecosystem
+        SpeciesRemoved = 1,
+        SpeciesReturned = 2,
+        PopulationCrashed = 3,
+        PopulationBoomed = 4,
+        CoralBleached = 5,
+        CoralRecovered = 6,
+        WentBarren = 7,
+        Recovering = 8,
+
+        // Octopuses
+        OctopusHatched = 20,
+        OctopusDied = 21,
+        OctopusMated = 22,
+        OctopusSettled = 23,
+        NewGeneration = 24,
+    }
+
+    [Serializable]
+    public struct ReefEvent
+    {
+        public ReefEventKind kind;
+        public int day;
+        public int subject;    // species index, or an octopus id
+        public int value;      // count, generation, cause of death — depends on kind
+        public int other;      // a second octopus id, or a generation number
+
+        // Births, deaths and new generations always outrank a percentage change in
+        // biomass (Milestone Step 3, risks). This is that ranking, as a number.
+        //
+        // Above all of them sit the two things the learner did themselves. A log that
+        // drops "you removed the parrotfish" but keeps every hatching has thrown away
+        // the cause and kept only the consequences — and the whole point of the log is
+        // that a learner can trace one to the other.
+        public int Rank => kind switch
+        {
+            ReefEventKind.SpeciesRemoved    => 110,
+            ReefEventKind.SpeciesReturned   => 105,
+            ReefEventKind.NewGeneration     => 100,
+            ReefEventKind.WentBarren        => 95,
+            ReefEventKind.OctopusHatched    => 90,
+            ReefEventKind.OctopusMated      => 85,
+            ReefEventKind.OctopusDied       => 80,
+            ReefEventKind.OctopusSettled    => 70,
+            ReefEventKind.CoralBleached     => 65,
+            ReefEventKind.Recovering        => 50,
+            ReefEventKind.CoralRecovered    => 45,
+            ReefEventKind.PopulationCrashed => 40,
+            ReefEventKind.PopulationBoomed  => 35,
+            _ => 0,
+        };
+    }
+
+    // The reef's diary: the last twenty things worth remembering.
+    //
+    // One list, three readers — the Welcome Back card, the report's "what happened"
+    // section, and the assistant's snapshot. Keeping one journal rather than three
+    // means they can never disagree about what occurred.
+    [Serializable]
+    public class ReefJournal
+    {
+        public const int Capacity = 20;
+        const int BytesPerEvent = 14;
+
+        readonly List<ReefEvent> _events = new List<ReefEvent>(Capacity);
+
+        public IReadOnlyList<ReefEvent> Events => _events;
+        public int Count => _events.Count;
+
+        public void Clear() => _events.Clear();
+
+        public void Add(ReefEventKind kind, int day, int subject = -1, int value = 0, int other = -1)
+        {
+            // Newest first, so reading the list is reading backwards in time.
+            _events.Insert(0, new ReefEvent
+            {
+                kind = kind, day = day, subject = subject, value = value, other = other,
+            });
+            if (_events.Count > Capacity) _events.RemoveAt(_events.Count - 1);
+        }
+
+        // The most notable events since a given day, ranked by kind first and recency
+        // second — which is what stops a Welcome Back card leading with "the fan alga
+        // is down four percent" when a whole generation was born.
+        public List<ReefEvent> Notable(int sinceDay, int limit)
+        {
+            var picked = new List<ReefEvent>(limit);
+            foreach (var e in _events)
+                if (e.day >= sinceDay) picked.Add(e);
+
+            picked.Sort((a, b) =>
+            {
+                int byRank = b.Rank.CompareTo(a.Rank);
+                return byRank != 0 ? byRank : b.day.CompareTo(a.day);
+            });
+
+            if (picked.Count > limit) picked.RemoveRange(limit, picked.Count - limit);
+            return picked;
+        }
+
+        // ── Wording ──────────────────────────────────────────────────────────
+        //
+        // Chosen at display time from the code, never stored. When the string tables
+        // are wired up, this is the single place that has to change.
+        public static string Describe(ReefEvent e, Genetics.OctopusPopulation octopuses)
+        {
+            string species = e.subject >= 0 && e.subject < SpeciesLibrary.Count
+                ? SpeciesLibrary.NameOf(e.subject).ToLowerInvariant()
+                : "something";
+
+            string who = octopuses != null && e.subject >= 0
+                ? octopuses.NameOf(e.subject) : "An octopus";
+            string mate = octopuses != null && e.other >= 0
+                ? octopuses.NameOf(e.other) : "another";
+
+            switch (e.kind)
+            {
+                case ReefEventKind.SpeciesRemoved:    return "You removed the " + species;
+                case ReefEventKind.SpeciesReturned:   return "The " + species + " was put back";
+                case ReefEventKind.PopulationCrashed: return "The " + species + " population fell sharply";
+                case ReefEventKind.PopulationBoomed:  return "The " + species + " population climbed sharply";
+                case ReefEventKind.CoralBleached:     return "The coral began to bleach";
+                case ReefEventKind.CoralRecovered:    return "The coral recovered its colour";
+                case ReefEventKind.WentBarren:        return "The reef went barren";
+                case ReefEventKind.Recovering:        return "The reef began to recover";
+
+                case ReefEventKind.OctopusHatched:
+                    return e.value > 1
+                        ? who + " hatched a brood of " + e.value + " (generation " + e.other + ")"
+                        : who + " hatched (generation " + e.other + ")";
+
+                case ReefEventKind.OctopusDied:
+                    return who + " " + Genetics.OctopusAgent.CauseWord((Genetics.CauseOfDeath)e.value);
+
+                case ReefEventKind.OctopusMated:      return who + " and " + mate + " mated";
+                case ReefEventKind.OctopusSettled:    return who + " settled here from the plankton";
+                case ReefEventKind.NewGeneration:     return "A new generation hatched (generation " + e.value + ")";
+
+                default: return "";
+            }
+        }
+
+        // ── Persistence ──────────────────────────────────────────────────────
+        // Five small numbers per event, packed rather than written as JSON objects.
+
+        public string Pack()
+        {
+            if (_events.Count == 0) return "";
+
+            var bytes = new byte[_events.Count * BytesPerEvent];
+            int at = 0;
+            foreach (var e in _events)
+            {
+                bytes[at++] = (byte)e.kind;
+                WriteInt(bytes, ref at, e.day);
+                WriteInt(bytes, ref at, e.subject);
+                WriteInt(bytes, ref at, e.value);
+                bytes[at++] = (byte)Mathf.Clamp(e.other + 1, 0, 255);
+            }
+            return Convert.ToBase64String(bytes);
+        }
+
+        public void Unpack(string packed)
+        {
+            Clear();
+            if (string.IsNullOrEmpty(packed)) return;
+
+            try
+            {
+                var bytes = Convert.FromBase64String(packed);
+                int at = 0;
+                while (at + BytesPerEvent <= bytes.Length && _events.Count < Capacity)
+                {
+                    var e = new ReefEvent { kind = (ReefEventKind)bytes[at++] };
+                    e.day = ReadInt(bytes, ref at);
+                    e.subject = ReadInt(bytes, ref at);
+                    e.value = ReadInt(bytes, ref at);
+                    e.other = bytes[at++] - 1;
+                    _events.Add(e);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning("[ReefJournal] Could not read the saved journal: " + ex.Message);
+                Clear();
+            }
+        }
+
+        static void WriteInt(byte[] b, ref int at, int v)
+        {
+            b[at++] = (byte)(v & 0xFF);
+            b[at++] = (byte)((v >> 8) & 0xFF);
+            b[at++] = (byte)((v >> 16) & 0xFF);
+            b[at++] = (byte)((v >> 24) & 0xFF);
+        }
+
+        static int ReadInt(byte[] b, ref int at)
+        {
+            int v = b[at] | (b[at + 1] << 8) | (b[at + 2] << 16) | (b[at + 3] << 24);
+            at += 4;
+            return v;
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Memory/ReefJournal.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Memory/ReefJournal.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1b5ca986e4f73d24299754c2180b55ea

--- a/Assets/Scripts/LivingEcosystem/Memory/ReefSave.cs
+++ b/Assets/Scripts/LivingEcosystem/Memory/ReefSave.cs
@@ -1,0 +1,318 @@
+using System;
+using System.IO;
+using UnityEngine;
+using CreateEnv.Ecosystem.Genetics;
+
+namespace CreateEnv.Ecosystem.Memory
+{
+    // The reef, written down.
+    //
+    // JsonUtility-friendly: only primitives and arrays of them. Anything that would
+    // be bulky as JSON — the octopuses, the pedigree, the history, the journal — is
+    // packed into bytes and carried as one base64 string each. Written out as plain
+    // JSON objects the file came to twelve kilobytes against a four kilobyte budget;
+    // packed it lands around three.
+    [Serializable]
+    public class ReefSave
+    {
+        public const int Format = 1;
+
+        public int format = Format;
+        public int rosterVersion;
+        public string environmentId = "";
+        public int seed;
+        public int day;
+        public string closedAtUtc = "";
+
+        // Settings the learner chose
+        public float temperatureC = 24f;
+        public float acidityPh = 8.1f;
+        public int speed = 1;
+        public int startingLife = 1;
+        public int predictionIndex = -1;
+        public bool[] present;
+
+        // Pools
+        public float[] biomass;
+        public float[] count;
+        public float[] energy;
+        public int[] daysHungry;
+        public float detritus;
+
+        // Octopuses and their pedigree
+        public string octopuses = "";
+        public string ancestors = "";
+        public int nextId, nextNameIndex, highestGeneration, totalBorn, totalDied;
+
+        // What the reef remembers
+        public string history = "";
+        public int historyFirstDay, historyLastDay;
+        public string journal = "";
+
+        // ── Capture ──────────────────────────────────────────────────────────
+
+        public static ReefSave From(string environmentId, EcosystemSettings settings,
+                                    EcosystemSimulation sim, OctopusPopulation octopuses,
+                                    ReefChronicle chronicle)
+        {
+            int n = SpeciesLibrary.Count;
+            var save = new ReefSave
+            {
+                rosterVersion = SpeciesLibrary.RosterVersion,
+                environmentId = environmentId ?? "",
+                seed = sim.seed,
+                day = sim.day,
+                closedAtUtc = DateTime.UtcNow.ToString("o"),
+
+                temperatureC = sim.temperatureC,
+                acidityPh = sim.acidityPh,
+                speed = settings != null ? settings.speed : 1,
+                startingLife = settings != null ? settings.startingLife : 1,
+                predictionIndex = settings != null ? settings.predictionIndex : -1,
+
+                present = new bool[n],
+                biomass = new float[n],
+                count = new float[n],
+                energy = new float[n],
+                daysHungry = new int[n],
+                detritus = sim.detritus,
+            };
+
+            for (int i = 0; i < n; i++)
+            {
+                save.present[i] = sim.IsPresent(i);
+                save.biomass[i] = sim.pools[i].biomass;
+                save.count[i] = sim.pools[i].count;
+                save.energy[i] = sim.pools[i].energy;
+                save.daysHungry[i] = sim.pools[i].daysHungry;
+            }
+
+            if (octopuses != null)
+            {
+                save.octopuses = PackAgents(octopuses);
+                save.ancestors = PackAncestors(octopuses);
+                save.highestGeneration = octopuses.HighestGeneration;
+                save.totalBorn = octopuses.TotalBorn;
+                save.totalDied = octopuses.TotalDied;
+                save.nextId = octopuses.NextId;
+                save.nextNameIndex = octopuses.NextNameIndex;
+            }
+
+            if (chronicle != null)
+            {
+                save.history = chronicle.history.Pack();
+                save.historyFirstDay = chronicle.history.firstDay;
+                save.historyLastDay = chronicle.history.lastSampledDay;
+                save.journal = chronicle.journal.Pack();
+            }
+
+            return save;
+        }
+
+        // ── Restore ──────────────────────────────────────────────────────────
+
+        public void ApplyTo(EcosystemSettings settings, EcosystemSimulation sim,
+                            OctopusPopulation octopuses, ReefChronicle chronicle)
+        {
+            int n = Mathf.Min(SpeciesLibrary.Count, biomass != null ? biomass.Length : 0);
+
+            if (settings != null)
+            {
+                settings.temperatureC = temperatureC;
+                settings.acidityPh = acidityPh;
+                settings.speed = speed;
+                settings.startingLife = startingLife;
+                settings.predictionIndex = predictionIndex;
+                if (present != null && settings.present != null)
+                    for (int i = 0; i < Mathf.Min(present.Length, settings.present.Length); i++)
+                        settings.present[i] = present[i];
+                settings.Clamp();
+            }
+
+            sim.day = day;
+            sim.temperatureC = temperatureC;
+            sim.acidityPh = acidityPh;
+            sim.detritus = detritus;
+
+            for (int i = 0; i < n; i++)
+            {
+                if (present != null && i < present.Length && sim.present != null && i < sim.present.Length)
+                    sim.present[i] = present[i];
+
+                sim.pools[i] = default;
+                sim.pools[i].biomass = biomass[i];
+                sim.pools[i].count = count != null && i < count.Length ? count[i] : 0f;
+                sim.pools[i].energy = energy != null && i < energy.Length ? energy[i] : 0f;
+                sim.pools[i].daysHungry = daysHungry != null && i < daysHungry.Length ? daysHungry[i] : 0;
+            }
+
+            if (octopuses != null)
+                octopuses.Restore(UnpackAgents(), UnpackAncestors(),
+                                  nextId, nextNameIndex, highestGeneration, totalBorn, totalDied);
+
+            if (chronicle != null)
+            {
+                chronicle.history.Unpack(history, historyFirstDay, historyLastDay);
+                chronicle.journal.Unpack(journal);
+            }
+        }
+
+        // ── Packing ──────────────────────────────────────────────────────────
+
+        static string PackAgents(OctopusPopulation pop)
+        {
+            using var stream = new MemoryStream();
+            using var w = new BinaryWriter(stream);
+
+            w.Write((byte)pop.agents.Count);
+            foreach (var a in pop.agents)
+            {
+                w.Write(a.id);
+                w.Write(pop.NameIndexOf(a.id));
+                w.Write(a.genome.camouflage);
+                w.Write(a.genome.bodySize);
+                w.Write(a.genome.heatTolerance);
+                w.Write((byte)a.sex);
+                w.Write((byte)Mathf.Clamp(a.generation, 0, 255));
+                w.Write(a.motherId);
+                w.Write(a.fatherId);
+                w.Write(a.ageDays);
+                w.Write(a.energy);
+                w.Write((byte)a.state);
+                w.Write(a.noiseSeed);
+                w.Write(a.broodDaysRemaining);
+                w.Write((byte)Mathf.Clamp(a.pendingYoung, 0, 255));
+                w.Write(a.declineDaysRemaining);
+                w.Write(a.storedMate.camouflage);
+                w.Write(a.storedMate.bodySize);
+                w.Write(a.storedMate.heatTolerance);
+                w.Write(a.storedMateId);
+                w.Write(a.bornOnDay);
+            }
+            w.Flush();
+            return Convert.ToBase64String(stream.ToArray());
+        }
+
+        OctopusAgent[] UnpackAgents()
+        {
+            if (string.IsNullOrEmpty(octopuses)) return Array.Empty<OctopusAgent>();
+
+            try
+            {
+                var bytes = Convert.FromBase64String(octopuses);
+                using var stream = new MemoryStream(bytes);
+                using var r = new BinaryReader(stream);
+
+                int n = r.ReadByte();
+                var list = new OctopusAgent[n];
+                for (int i = 0; i < n; i++)
+                {
+                    var a = new OctopusAgent();
+                    a.id = r.ReadInt32();
+                    a.nameIndex = r.ReadInt32();
+                    a.genome.camouflage = r.ReadByte();
+                    a.genome.bodySize = r.ReadByte();
+                    a.genome.heatTolerance = r.ReadByte();
+                    a.sex = (Sex)r.ReadByte();
+                    a.generation = r.ReadByte();
+                    a.motherId = r.ReadInt32();
+                    a.fatherId = r.ReadInt32();
+                    a.ageDays = r.ReadSingle();
+                    a.energy = r.ReadSingle();
+                    a.state = (OctopusState)r.ReadByte();
+                    a.noiseSeed = r.ReadSingle();
+                    a.broodDaysRemaining = r.ReadSingle();
+                    a.pendingYoung = r.ReadByte();
+                    a.declineDaysRemaining = r.ReadSingle();
+                    a.storedMate.camouflage = r.ReadByte();
+                    a.storedMate.bodySize = r.ReadByte();
+                    a.storedMate.heatTolerance = r.ReadByte();
+                    a.storedMateId = r.ReadInt32();
+                    a.bornOnDay = r.ReadInt32();
+                    a.name = OctopusNames.At(a.nameIndex);
+                    a.RefreshTraits();
+                    list[i] = a;
+                }
+                return list;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning("[ReefSave] Could not read the saved octopuses: " + e.Message);
+                return Array.Empty<OctopusAgent>();
+            }
+        }
+
+        static string PackAncestors(OctopusPopulation pop)
+        {
+            using var stream = new MemoryStream();
+            using var w = new BinaryWriter(stream);
+
+            w.Write((ushort)pop.ancestors.Count);
+            foreach (var r in pop.ancestors)
+            {
+                w.Write(r.id);
+                w.Write(r.nameIndex);
+                w.Write(r.genome.camouflage);
+                w.Write(r.genome.bodySize);
+                w.Write(r.genome.heatTolerance);
+                w.Write(r.generation);
+                w.Write(r.sexAndCause);
+                w.Write(r.motherId);
+                w.Write(r.fatherId);
+                w.Write(r.diedOnDay);
+                w.Write(r.ageAtDeath);
+            }
+            w.Flush();
+            return Convert.ToBase64String(stream.ToArray());
+        }
+
+        AncestorRecord[] UnpackAncestors()
+        {
+            if (string.IsNullOrEmpty(ancestors)) return Array.Empty<AncestorRecord>();
+
+            try
+            {
+                var bytes = Convert.FromBase64String(ancestors);
+                using var stream = new MemoryStream(bytes);
+                using var r = new BinaryReader(stream);
+
+                int n = r.ReadUInt16();
+                var list = new AncestorRecord[n];
+                for (int i = 0; i < n; i++)
+                {
+                    var rec = new AncestorRecord();
+                    rec.id = r.ReadInt32();
+                    rec.nameIndex = r.ReadInt32();
+                    rec.genome.camouflage = r.ReadByte();
+                    rec.genome.bodySize = r.ReadByte();
+                    rec.genome.heatTolerance = r.ReadByte();
+                    rec.generation = r.ReadByte();
+                    rec.sexAndCause = r.ReadByte();
+                    rec.motherId = r.ReadInt32();
+                    rec.fatherId = r.ReadInt32();
+                    rec.diedOnDay = r.ReadInt16();
+                    rec.ageAtDeath = r.ReadInt16();
+                    list[i] = rec;
+                }
+                return list;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning("[ReefSave] Could not read the saved pedigree: " + e.Message);
+                return Array.Empty<AncestorRecord>();
+            }
+        }
+
+        // How long the learner has been away, in real hours. Negative results — a
+        // device clock moved backwards — count as no time at all rather than as
+        // time travel.
+        public double HoursAway(DateTime nowUtc)
+        {
+            if (string.IsNullOrEmpty(closedAtUtc)) return 0.0;
+            if (!DateTime.TryParse(closedAtUtc, null,
+                    System.Globalization.DateTimeStyles.RoundtripKind, out var closed))
+                return 0.0;
+            return Math.Max(0.0, (nowUtc - closed).TotalHours);
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Memory/ReefSave.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Memory/ReefSave.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ed90b86cd54354d43ae71273b4952827

--- a/Assets/Scripts/LivingEcosystem/Memory/ReefSaveFile.cs
+++ b/Assets/Scripts/LivingEcosystem/Memory/ReefSaveFile.cs
@@ -1,0 +1,152 @@
+using System;
+using System.IO;
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem.Memory
+{
+    // Where a reef lives between sessions.
+    //
+    // One small file per environment, on the device. No server and no account
+    // (Design Document 8.3). Sits beside the environment profiles the builder
+    // already writes, so a learner's saved worlds and their saved reefs are in the
+    // same place.
+    public static class ReefSaveFile
+    {
+        public const int BudgetBytes = 4096;
+
+        public static string Folder =>
+            Path.Combine(Application.persistentDataPath, "reefs");
+
+        public static string PathFor(string environmentId)
+        {
+            string id = string.IsNullOrEmpty(environmentId) ? "default" : environmentId;
+            return Path.Combine(Folder, id + ".json");
+        }
+
+        public static bool Exists(string environmentId) => File.Exists(PathFor(environmentId));
+
+        public static void Write(ReefSave save)
+        {
+            if (save == null) return;
+
+            try
+            {
+                Directory.CreateDirectory(Folder);
+                string json = JsonUtility.ToJson(save);
+                File.WriteAllText(PathFor(save.environmentId), json);
+
+                // The budget is a design constraint, not a hard limit, so exceeding it
+                // is a warning rather than a failure — but it should never pass
+                // unnoticed, because the packing exists precisely to stay under it.
+                int bytes = System.Text.Encoding.UTF8.GetByteCount(json);
+                if (bytes > BudgetBytes)
+                    Debug.LogWarning($"[ReefSave] '{save.environmentId}' wrote {bytes} bytes, " +
+                                     $"over the {BudgetBytes} byte budget.");
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning("[ReefSave] Could not write the reef: " + e.Message);
+            }
+        }
+
+        public static ReefSave Read(string environmentId)
+        {
+            string path = PathFor(environmentId);
+            if (!File.Exists(path)) return null;
+
+            try
+            {
+                var save = JsonUtility.FromJson<ReefSave>(File.ReadAllText(path));
+                if (save == null) return null;
+
+                if (save.format != ReefSave.Format)
+                {
+                    Debug.Log($"[ReefSave] Ignoring '{environmentId}': written in format " +
+                              $"{save.format}, this build reads {ReefSave.Format}.");
+                    return null;
+                }
+
+                // The species order is the wire format for every index in the file.
+                // A save written against a different roster would put one species'
+                // numbers into another's pool.
+                if (save.rosterVersion != SpeciesLibrary.RosterVersion)
+                {
+                    Debug.Log($"[ReefSave] Ignoring '{environmentId}': written against roster " +
+                              $"version {save.rosterVersion}, this build uses " +
+                              $"{SpeciesLibrary.RosterVersion}. The reef will start fresh.");
+                    return null;
+                }
+
+                return save;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning("[ReefSave] Could not read the reef: " + e.Message);
+                return null;
+            }
+        }
+
+        public static void Delete(string environmentId)
+        {
+            try
+            {
+                string path = PathFor(environmentId);
+                if (File.Exists(path)) File.Delete(path);
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning("[ReefSave] Could not delete the reef: " + e.Message);
+            }
+        }
+
+        public static int SizeOf(string environmentId)
+        {
+            string path = PathFor(environmentId);
+            return File.Exists(path) ? (int)new FileInfo(path).Length : 0;
+        }
+    }
+
+    // How much time passed in the ocean while the learner was elsewhere.
+    //
+    // "An hour away is a day in your ocean, up to two weeks." That sentence is all a
+    // learner ever needs to know about time (Design Document 8.1), and the cap is
+    // what stops someone returning after a month to a reef that starved to death
+    // without them.
+    //
+    // This reads wall-clock time from the save file's timestamp. It has nothing to do
+    // with the in-scene clock, which counts Time.deltaTime while the app is running —
+    // the two never interact, so away-time can never disturb a live session.
+    public static class TimeAway
+    {
+        public const double RealHoursPerDay = 1.0;
+        public const int MaximumDays = 14;
+
+        // Under an hour away is not worth a card (Design Document 8.2).
+        public const double MinimumHoursToReport = 1.0;
+
+        public struct Result
+        {
+            public double hoursAway;
+            public int daysToRun;      // after the cap
+            public int uncappedDays;   // what it would have been
+            public bool wasCapped;
+            public bool worthReporting;
+        }
+
+        public static Result Measure(double hoursAway)
+        {
+            hoursAway = Math.Max(0.0, hoursAway);
+            int uncapped = (int)Math.Floor(hoursAway / RealHoursPerDay);
+            int capped = Mathf.Clamp(uncapped, 0, MaximumDays);
+
+            return new Result
+            {
+                hoursAway = hoursAway,
+                daysToRun = capped,
+                uncappedDays = uncapped,
+                wasCapped = uncapped > MaximumDays,
+                worthReporting = hoursAway >= MinimumHoursToReport && capped > 0,
+            };
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Memory/ReefSaveFile.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Memory/ReefSaveFile.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a349fa8bd356041409ad2116e10c069c

--- a/Assets/Scripts/LivingEcosystem/Memory/ReportShare.cs
+++ b/Assets/Scripts/LivingEcosystem/Memory/ReportShare.cs
@@ -1,0 +1,209 @@
+using System;
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem.Memory
+{
+    // Getting the report out of the app.
+    //
+    // On Android the file goes into the phone's Downloads folder through MediaStore
+    // and is then offered to the share sheet. That route was chosen because it needs
+    // no FileProvider entry, and therefore no change to AndroidManifest.xml — a file
+    // shared by every scene in the project, including the ones this feature is not
+    // allowed to touch. The project's minimum SDK is 29, which is exactly where
+    // MediaStore's Downloads collection became available, so nothing is given up.
+    //
+    // It also means the PDF survives the app being uninstalled, which is the right
+    // behaviour for something a learner is meant to hand in.
+    //
+    // In the Editor there is no share sheet, so the file is written and revealed in
+    // Explorer instead. Same PDF, same code path up to the last step.
+    public static class ReportShare
+    {
+        public struct Result
+        {
+            public bool ok;
+            public string path;        // where it ended up
+            public string failure;     // null when ok
+
+            // What the toast says. Built here rather than in the interface because
+            // only this code knows which route the file actually took — Downloads via
+            // the share sheet, or a folder on a desktop.
+            public string message;
+        }
+
+        // The one call the interface makes: build the report from a running reef and
+        // hand it to the platform. Keeping the controller out of EcosystemReport is
+        // what lets the report itself be built and checked without a scene.
+        public static Result ShareReport(LivingReefController reef, string environmentName)
+        {
+            if (reef == null || reef.Sim == null)
+                return Failed("There is no reef to report on yet.");
+
+            byte[] pdf;
+            try
+            {
+                pdf = EcosystemReport.Build(new EcosystemReport.Source
+                {
+                    environmentName = environmentName,
+                    sim = reef.Sim,
+                    health = reef.Health,
+                    settings = reef.Settings,
+                    octopuses = reef.Octopuses,
+                    chronicle = reef.Chronicle,
+                    reasons = reef.Reasons != null ? reef.Reasons.Active : null,
+                });
+            }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+                return Failed("The report could not be put together.");
+            }
+
+            return Share(pdf, EcosystemReport.FileNameFor(environmentName));
+        }
+
+        static Result Failed(string why) =>
+            new Result { failure = why, message = "Could not save the report. " + why };
+
+        public static Result Share(byte[] pdf, string fileName)
+        {
+            if (pdf == null || pdf.Length == 0)
+                return Failed("The report came out empty.");
+
+            if (!fileName.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase))
+                fileName += ".pdf";
+
+#if UNITY_ANDROID && !UNITY_EDITOR
+            return ShareOnAndroid(pdf, fileName);
+#else
+            return SaveLocally(pdf, fileName);
+#endif
+        }
+
+        // ── Editor and desktop ───────────────────────────────────────────────
+
+        static Result SaveLocally(byte[] pdf, string fileName)
+        {
+            try
+            {
+                string folder = System.IO.Path.Combine(Application.persistentDataPath, "reports");
+                System.IO.Directory.CreateDirectory(folder);
+
+                string path = System.IO.Path.Combine(folder, fileName);
+                System.IO.File.WriteAllBytes(path, pdf);
+
+#if UNITY_EDITOR
+                UnityEditor.EditorUtility.RevealInFinder(path);
+#endif
+                Debug.Log("[ReefReport] Written to " + path);
+                return new Result
+                {
+                    ok = true,
+                    path = path,
+                    message = "Saved as " + fileName + Environment.NewLine + "in " + folder,
+                };
+            }
+            catch (Exception e)
+            {
+                return Failed(e.Message);
+            }
+        }
+
+#if UNITY_ANDROID && !UNITY_EDITOR
+        static Result ShareOnAndroid(byte[] pdf, string fileName)
+        {
+            try
+            {
+                using var player = new AndroidJavaClass("com.unity3d.player.UnityPlayer");
+                using var activity = player.GetStatic<AndroidJavaObject>("currentActivity");
+                using var resolver = activity.Call<AndroidJavaObject>("getContentResolver");
+
+                using var environment = new AndroidJavaClass("android.os.Environment");
+                string downloads = environment.GetStatic<string>("DIRECTORY_DOWNLOADS");
+
+                using var values = new AndroidJavaObject("android.content.ContentValues");
+                values.Call("put", "_display_name", fileName);
+                values.Call("put", "mime_type", "application/pdf");
+                values.Call("put", "relative_path", downloads);
+
+                // Marked pending while the bytes are written, so no other app can read a
+                // half-finished PDF out of Downloads.
+                using (var pending = new AndroidJavaObject("java.lang.Integer", 1))
+                    values.Call("put", "is_pending", pending);
+
+                using var downloadsClass = new AndroidJavaClass("android.provider.MediaStore$Downloads");
+                using var collection = downloadsClass.GetStatic<AndroidJavaObject>("EXTERNAL_CONTENT_URI");
+
+                var item = resolver.Call<AndroidJavaObject>("insert", collection, values);
+                if (item == null)
+                    return Failed("Android would not make room in Downloads.");
+
+                using (var stream = resolver.Call<AndroidJavaObject>("openOutputStream", item))
+                {
+                    if (stream == null)
+                        return Failed("Android would not open the file for writing.");
+
+                    stream.Call("write", pdf);
+                    stream.Call("flush");
+                    stream.Call("close");
+                }
+
+                // Clearing the pending flag is what makes the file visible in Downloads.
+                // It is done defensively: if the JNI call cannot resolve, the bytes are
+                // already written, and losing visibility is better than losing the file.
+                try
+                {
+                    using var done = new AndroidJavaObject("android.content.ContentValues");
+                    using var cleared = new AndroidJavaObject("java.lang.Integer", 0);
+                    done.Call("put", "is_pending", cleared);
+                    resolver.Call<int>("update", item, done, null, null);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogWarning("[ReefReport] Could not clear the pending flag: " + e.Message);
+                }
+
+                // The file is safely on the device at this point. The share sheet is a
+                // bonus: if it fails, the learner still has their report.
+                string where = downloads + "/" + fileName;
+                try
+                {
+                    using var send = new AndroidJavaObject("android.content.Intent", "android.intent.action.SEND");
+                    send.Call<AndroidJavaObject>("setType", "application/pdf");
+                    send.Call<AndroidJavaObject>("putExtra", "android.intent.extra.STREAM", item);
+                    send.Call<AndroidJavaObject>("putExtra", "android.intent.extra.SUBJECT", "My reef report");
+                    send.Call<AndroidJavaObject>("addFlags", 1);   // FLAG_GRANT_READ_URI_PERMISSION
+
+                    using var intentClass = new AndroidJavaClass("android.content.Intent");
+                    using var chooser = intentClass.CallStatic<AndroidJavaObject>(
+                        "createChooser", send, "Share your reef report");
+
+                    activity.Call("startActivity", chooser);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogWarning("[ReefReport] Saved, but the share sheet did not open: " + e.Message);
+                    return new Result
+                    {
+                        ok = true,
+                        path = where,
+                        message = "Saved to your Downloads folder as " + fileName,
+                    };
+                }
+
+                item.Dispose();
+                return new Result
+                {
+                    ok = true,
+                    path = where,
+                    message = "Saved to your Downloads folder as " + fileName,
+                };
+            }
+            catch (Exception e)
+            {
+                return Failed(e.Message);
+            }
+        }
+#endif
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Memory/ReportShare.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Memory/ReportShare.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 690e7072018790241bac11d53b7bb44c

--- a/Assets/Scripts/LivingEcosystem/Reasoning.meta
+++ b/Assets/Scripts/LivingEcosystem/Reasoning.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d8573778c9c570244a819a64ba7faa1f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/LivingEcosystem/Reasoning/EcosystemWarnings.cs
+++ b/Assets/Scripts/LivingEcosystem/Reasoning/EcosystemWarnings.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+
+namespace CreateEnv.Ecosystem
+{
+    // Guard rails, not blocks. The learner is always allowed to build an unbalanced
+    // ecosystem — breaking it is the lesson. A one-line warning as choices are made
+    // turns a broken ecosystem into a taught one (Design Document 5.1).
+    //
+    // A lookup table of about a dozen strings and no new simulation logic.
+    public static class EcosystemWarnings
+    {
+        // Every warning that applies to the current selection, most important first.
+        public static List<string> For(bool[] present)
+        {
+            var list = new List<string>(4);
+            if (present == null || present.Length < SpeciesLibrary.Count) return list;
+
+            bool On(int i) => present[i];
+
+            bool anyProducer = On(SpeciesLibrary.Halimeda) || On(SpeciesLibrary.Padina) || On(SpeciesLibrary.Coral);
+            bool anyAlga     = On(SpeciesLibrary.Halimeda) || On(SpeciesLibrary.Padina);
+            bool anyGrazer   = On(SpeciesLibrary.Parrotfish) || On(SpeciesLibrary.Urchin)
+                            || On(SpeciesLibrary.Limpet) || On(SpeciesLibrary.Lobster);
+
+            if (!anyProducer)
+                list.Add("With no producers, nothing captures energy from sunlight. Everything will starve within a few dozen days.");
+            else if (!anyAlga)
+                list.Add("With only coral, there is almost nothing to graze. The coral grows far too slowly to feed anything.");
+
+            if (!anyGrazer && anyAlga)
+                list.Add("With no plant eaters, algae will grow unchecked and can smother the coral.");
+
+            if (!On(SpeciesLibrary.TigerShark) && On(SpeciesLibrary.Urchin))
+                list.Add("With no tiger shark, nothing hunts the urchins. Expect them to multiply and strip the algae.");
+
+            if (!On(SpeciesLibrary.Parrotfish) && On(SpeciesLibrary.Urchin) && !On(SpeciesLibrary.TigerShark))
+                list.Add("Neither the shark nor the parrotfish is present. Nothing at all checks the urchins — a barren is very likely.");
+
+            if (!On(SpeciesLibrary.Octopus) && On(SpeciesLibrary.Lobster))
+                list.Add("With no octopus, lobsters have no predator here.");
+
+            if (On(SpeciesLibrary.Octopus) && !On(SpeciesLibrary.Lobster) && !On(SpeciesLibrary.Limpet))
+                list.Add("The octopus has nothing to hunt. It will starve.");
+
+            if (On(SpeciesLibrary.TigerShark) && !On(SpeciesLibrary.Parrotfish)
+                && !On(SpeciesLibrary.Urchin) && !On(SpeciesLibrary.Octopus))
+                list.Add("The tiger shark has nothing to hunt here.");
+
+            if (On(SpeciesLibrary.Coral) && !anyGrazer)
+                list.Add("Without grazers, fan alga tends to overgrow the coral and block its light.");
+
+            return list;
+        }
+
+        // The prediction prompt shown before entering: predict, observe, compare —
+        // the scientific method in three taps (Design Document 5.1).
+        public static readonly string[] PredictionOptions =
+        {
+            "The reef will stay balanced",
+            "One species will take over",
+            "The reef will collapse",
+        };
+
+        public const string PredictionQuestion = "What do you think will happen?";
+
+        // Which outcome actually occurred, as an index into PredictionOptions, so the
+        // app can compare it against what the learner predicted.
+        public static int OutcomeIndex(EcosystemHealth health, EcosystemSimulation sim)
+        {
+            if (health.stage >= CollapseStage.Collapse) return 2;
+
+            var all = SpeciesLibrary.All;
+            for (int i = 0; i < all.Length; i++)
+            {
+                if (all[i].IsProducer || all[i].transient) continue;
+                if (!sim.IsPresent(i)) continue;
+                if (sim.pools[i].count > all[i].startingStock * 2.2f) return 1;
+            }
+            return health.stage <= CollapseStage.Imbalance ? 0 : 1;
+        }
+
+        public static string CompareToPrediction(int predicted, int actual)
+        {
+            if (predicted < 0) return null;
+            string actualText = actual switch
+            {
+                0 => "the reef stayed balanced",
+                1 => "one species took over",
+                _ => "the reef collapsed",
+            };
+            return predicted == actual
+                ? $"You predicted this: {actualText}."
+                : $"You predicted \"{PredictionOptions[predicted]}\", and {actualText}.";
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Reasoning/EcosystemWarnings.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Reasoning/EcosystemWarnings.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d57f0f28a8062814da12a613abbb2a62

--- a/Assets/Scripts/LivingEcosystem/Reasoning/ReasonEngine.cs
+++ b/Assets/Scripts/LivingEcosystem/Reasoning/ReasonEngine.cs
@@ -1,0 +1,238 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem
+{
+    // One matched rule, ready to show.
+    public class Reason
+    {
+        public string id;            // stable key, also used by the snapshot
+        public string whatIsHappening;
+        public string whyItIsHappening;
+        public string whatHappensNext;
+        public int    priority;
+    }
+
+    // The Why panel's reasoning. Not artificial intelligence: a small rule-based
+    // explainer, which keeps it instant, offline, deterministic and impossible to
+    // get wrong (Design Document 6.2).
+    //
+    // Each rule is: condition -> cause string + consequence string. They are
+    // evaluated once per tick, in priority order, and the first three that match are
+    // shown. Every string here should trace to the Literature Document, and every
+    // rule needs a biologist's review of cause and consequence before release —
+    // pre-release checklist item 6.
+    //
+    // Wording rule, from Literature 3.6: populations change because some individuals
+    // leave more descendants than others. Never write as though an animal adapts on
+    // purpose or within its own lifetime.
+    public class ReasonEngine
+    {
+        readonly List<Reason> _active = new List<Reason>(8);
+        readonly TrendTracker[] _trends = new TrendTracker[SpeciesLibrary.Count];
+        readonly TrendTracker _producerTrend = new TrendTracker(20);
+
+        public IReadOnlyList<Reason> Active => _active;
+
+        public ReasonEngine()
+        {
+            for (int i = 0; i < _trends.Length; i++)
+                _trends[i] = new TrendTracker(20);
+        }
+
+        public void Reset()
+        {
+            _active.Clear();
+            _producerTrend.Reset();
+            for (int i = 0; i < _trends.Length; i++) _trends[i].Reset();
+        }
+
+        public void Observe(EcosystemSimulation sim)
+        {
+            for (int i = 0; i < SpeciesLibrary.Count; i++)
+                _trends[i].Push(sim.DisplayAmount(i));
+            // Grazeable only: the ungrazed coral would otherwise mask a seafloor
+            // being stripped, and "the algae are shrinking" would never fire.
+            _producerTrend.Push(sim.GrazeableProducerBiomass());
+        }
+
+        public int TrendOf(int species) => _trends[species].Direction;
+        public float ChangeOf(int species) => _trends[species].Change;
+
+        // Evaluates the whole rule set and keeps the three strongest matches.
+        public void Evaluate(EcosystemSimulation sim, EcosystemHealth health)
+        {
+            _active.Clear();
+            var all = SpeciesLibrary.All;
+
+            // ── Predator removal and its cascade ─────────────────────────────
+            // grazer rising AND its predator absent -> "predator removed"
+            if (!sim.IsPresent(SpeciesLibrary.TigerShark) && TrendOf(SpeciesLibrary.Urchin) > 0)
+                Add("predator removed", 100,
+                    $"{Cap(Name(SpeciesLibrary.Urchin))}s are increasing quickly.",
+                    "You removed the tiger shark. Nothing is hunting the urchins now, so more of them survive to breed.",
+                    "If this continues, the algae will run out and the urchins will starve. The coral may be smothered first.");
+
+            if (!sim.IsPresent(SpeciesLibrary.TigerShark) && TrendOf(SpeciesLibrary.Octopus) > 0)
+                Add("mesopredator release", 70,
+                    "Octopuses are becoming more common.",
+                    "With the tiger shark gone, the octopus is no longer hunted and no longer has to hide. A mid-level hunter freed like this is called a released mesopredator.",
+                    "Lobsters and limpets will come under heavier pressure than before.");
+
+            // ── Overgrazing ──────────────────────────────────────────────────
+            // producer biomass falling AND grazer count rising -> "overgrazing"
+            bool producersFalling = _producerTrend.Direction < 0;
+            int risingGrazer = FirstRisingGrazer(sim);
+            if (producersFalling && risingGrazer >= 0)
+                Add("overgrazing", 90,
+                    $"The algae are shrinking while {Name(risingGrazer)}s increase.",
+                    $"{Cap(Name(risingGrazer))}s are eating the algae faster than the algae can regrow.",
+                    "The algae will keep falling until there is not enough food, and then the grazers will starve.");
+
+            if (producersFalling && risingGrazer < 0 && health.ProducerFraction < 0.8f)
+                Add("producers falling", 60,
+                    "The algae are shrinking.",
+                    "More is being taken from the algae each day than they manage to grow back.",
+                    "If nothing changes, the animals that depend on them will start to run short.");
+
+            // ── Starvation ───────────────────────────────────────────────────
+            // consumer energy negative for 5+ days -> "starvation"
+            for (int i = 0; i < all.Length; i++)
+            {
+                if (all[i].IsProducer || all[i].transient) continue;
+                if (!sim.IsPresent(i) || sim.pools[i].count <= 0f) continue;
+                if (sim.pools[i].daysHungry < 5) continue;
+
+                Add("starvation:" + all[i].id, 85,
+                    $"{Cap(Name(i))}s are starting to starve.",
+                    $"There is not enough food for the number of {Name(i)}s now living here, so they are using more energy than they take in.",
+                    $"Their numbers will fall until the survivors can feed themselves.");
+                break; // one starvation line is enough; the panel shows three reasons
+            }
+
+            // ── Water conditions ─────────────────────────────────────────────
+            // producer capacity reduced AND temperature above threshold -> "water too warm"
+            int bleaching = FirstBleaching(sim);
+            if (bleaching >= 0)
+                Add("water too warm", 95,
+                    "The coral is bleaching.",
+                    "The water is too warm, so the coral has expelled the algae living in its tissue. Those algae supplied most of its food, and its colour.",
+                    "Bleached coral is not dead. If the water cools soon it can recover; if the heat lasts, it starves.");
+
+            if (sim.temperatureC > 28f && bleaching < 0)
+                Add("warm water", 50,
+                    "The water is warm.",
+                    "Warmer water raises the metabolic rate of cold-blooded animals, so they need more food simply to stay alive.",
+                    "Animals will need to eat more, and the algae will grow less well above their best temperature.");
+
+            if (sim.acidityPh < 7.95f)
+                Add("acidified water", 55,
+                    "The water is more acidic than normal.",
+                    "Acidified water makes it harder to build skeletons and shells from calcium carbonate. Corals, calcareous algae and snails are affected first; soft-bodied animals much less so.",
+                    "The coral, the green alga and the limpets will grow more slowly than the others.");
+
+            // ── Missing pieces of the web ────────────────────────────────────
+            if (!AnyPresent(sim, TrophicLevel.PlantEater))
+                Add("no grazers", 88,
+                    "Nothing is eating the algae.",
+                    "You removed every plant eater, so nothing is grazing.",
+                    "The algae will grow unchecked and can overgrow the coral, blocking its light.");
+
+            if (!AnyPresent(sim, TrophicLevel.Producer))
+                Add("no producers", 99,
+                    "There are no producers left.",
+                    "Nothing here is capturing energy from sunlight, so no new energy is entering the ecosystem at all.",
+                    "Every animal will starve within a few dozen days. Only the detritus pool is left.");
+
+            // ── Recovery ─────────────────────────────────────────────────────
+            if (health.stage == CollapseStage.Healthy && _producerTrend.Direction > 0
+                && health.ProducerFraction > 0.9f)
+                Add("recovering", 20,
+                    "The reef is regrowing.",
+                    "Grazing has eased enough for the algae to grow back faster than they are eaten.",
+                    "As the algae return, the animals that feed on them can increase again — though recovery takes longer than the collapse did.");
+
+            if (_active.Count == 0)
+                Add("balanced", 10,
+                    "The reef is steady.",
+                    "Each population is eating about as much as its food can regrow, so nothing is climbing or falling quickly.",
+                    "Left alone, it should stay roughly like this. Change the water or remove a species to see what happens.");
+
+            _active.Sort((a, b) => b.priority.CompareTo(a.priority));
+            if (_active.Count > 3) _active.RemoveRange(3, _active.Count - 3);
+        }
+
+        // Three tappable starter questions matched to the current situation, drawn
+        // from the same rule set (Design Document 7.2). Learners who are unsure what
+        // to ask are the ones who most need the assistant.
+        public List<string> SuggestedQuestions(EcosystemSimulation sim)
+        {
+            var q = new List<string>(3);
+            foreach (var r in _active)
+            {
+                if (q.Count >= 3) break;
+                switch (r.id)
+                {
+                    case "predator removed": q.Add("Why are my urchins increasing?"); break;
+                    case "overgrazing":      q.Add("What will happen if I do nothing?"); break;
+                    case "water too warm":   q.Add("Why is the coral turning white?"); break;
+                    case "acidified water":  q.Add("What does acidity do to the reef?"); break;
+                    case "no producers":     q.Add("How do I fix this?"); break;
+                    case "no grazers":       q.Add("What happens if algae grow unchecked?"); break;
+                    case "mesopredator release": q.Add("Why are there more octopuses?"); break;
+                    default:
+                        if (r.id.StartsWith("starvation:")) q.Add("Why are animals starving?");
+                        break;
+                }
+            }
+            if (q.Count < 3) q.Add("What is happening in my reef?");
+            if (q.Count < 3) q.Add("How do I keep this reef balanced?");
+            if (q.Count < 3) q.Add("Which animal matters most here?");
+            return q;
+        }
+
+        void Add(string id, int priority, string what, string why, string next)
+        {
+            _active.Add(new Reason
+            {
+                id = id, priority = priority,
+                whatIsHappening = what, whyItIsHappening = why, whatHappensNext = next,
+            });
+        }
+
+        int FirstRisingGrazer(EcosystemSimulation sim)
+        {
+            var all = SpeciesLibrary.All;
+            int best = -1;
+            float bestChange = 0.10f;
+            for (int i = 0; i < all.Length; i++)
+            {
+                if (all[i].level != TrophicLevel.PlantEater) continue;
+                if (!sim.IsPresent(i) || sim.pools[i].count <= 0f) continue;
+                float c = ChangeOf(i);
+                if (c > bestChange) { bestChange = c; best = i; }
+            }
+            return best;
+        }
+
+        int FirstBleaching(EcosystemSimulation sim)
+        {
+            for (int i = 0; i < SpeciesLibrary.Count; i++)
+                if (sim.IsPresent(i) && sim.pools[i].bleached) return i;
+            return -1;
+        }
+
+        static bool AnyPresent(EcosystemSimulation sim, TrophicLevel level)
+        {
+            var all = SpeciesLibrary.All;
+            for (int i = 0; i < all.Length; i++)
+                if (all[i].level == level && sim.IsAlive(i)) return true;
+            return false;
+        }
+
+        static string Name(int i) => SpeciesLibrary.NameOf(i).ToLowerInvariant();
+
+        static string Cap(string s) =>
+            string.IsNullOrEmpty(s) ? s : char.ToUpperInvariant(s[0]) + s.Substring(1);
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Reasoning/ReasonEngine.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Reasoning/ReasonEngine.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 45d71f2d8a298d84197fc9a0edc9372c

--- a/Assets/Scripts/LivingEcosystem/Sim.meta
+++ b/Assets/Scripts/LivingEcosystem/Sim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a08f0f633191b7a4bb980a3bb62e4a1c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/LivingEcosystem/Sim/EcosystemClock.cs
+++ b/Assets/Scripts/LivingEcosystem/Sim/EcosystemClock.cs
@@ -1,0 +1,60 @@
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem
+{
+    // One tick equals one simulated day. Normal fires every 2 seconds, Fast every
+    // 0.25 seconds, Paused never (Design Document 3.2). Three options only.
+    //
+    // Catches up at most a handful of ticks per frame so a hitch or a long frame
+    // cannot turn into a burst of dozens of days the learner never sees.
+    public class EcosystemClock
+    {
+        const int MaxTicksPerFrame = 4;
+
+        public int speed = 1;
+        float _accumulator;
+
+        public bool IsPaused => Mathf.Clamp(speed, 0, 2) == 0;
+
+        public float SecondsPerDay =>
+            EcosystemSettings.SecondsPerDay[Mathf.Clamp(speed, 0, EcosystemSettings.SecondsPerDay.Length - 1)];
+
+        // Fraction of the way to the next tick, for smoothing the readouts.
+        public float TickProgress
+        {
+            get
+            {
+                float period = SecondsPerDay;
+                return period > 0f ? Mathf.Clamp01(_accumulator / period) : 0f;
+            }
+        }
+
+        public void Reset()
+        {
+            _accumulator = 0f;
+        }
+
+        // Returns how many days should elapse this frame.
+        public int Advance(float deltaTime)
+        {
+            if (IsPaused) { _accumulator = 0f; return 0; }
+
+            float period = SecondsPerDay;
+            if (period <= 0f) return 0;
+
+            _accumulator += deltaTime;
+
+            int ticks = 0;
+            while (_accumulator >= period && ticks < MaxTicksPerFrame)
+            {
+                _accumulator -= period;
+                ticks++;
+            }
+
+            // Drop any further backlog rather than letting it snowball.
+            if (_accumulator > period) _accumulator = 0f;
+
+            return ticks;
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Sim/EcosystemClock.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Sim/EcosystemClock.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fef1c5c59947da8428a1c26d6859f795

--- a/Assets/Scripts/LivingEcosystem/Sim/EcosystemHealth.cs
+++ b/Assets/Scripts/LivingEcosystem/Sim/EcosystemHealth.cs
@@ -1,0 +1,186 @@
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem
+{
+    public enum HealthLevel { Green = 0, Amber = 1, Red = 2 }
+
+    public enum CollapseStage
+    {
+        Healthy     = 0,
+        Imbalance   = 1,  // one population climbs abnormally
+        Overgrazing = 2,  // producer biomass visibly falling
+        Starvation  = 3,  // the overgrown population stops growing, then falls
+        Collapse    = 4,  // higher levels lose their food and decline
+        Barren      = 5,  // only detritus and the slowest-growing survivors remain
+    }
+
+    // Watches the simulation and decides how it is doing. Collapse is staged rather
+    // than instantaneous so each stage can be read as it passes
+    // (Design Document 6.3). Stages only advance while things are getting worse;
+    // recovery walks them back down, because a learner who fixes the reef should see
+    // it say so.
+    public class EcosystemHealth
+    {
+        public HealthLevel level = HealthLevel.Green;
+        public CollapseStage stage = CollapseStage.Healthy;
+
+        // Producer biomass when the reef was last healthy — the yardstick everything
+        // else is measured against.
+        public float baselineProducers;
+        public int   stageEnteredDay;
+
+        readonly TrendTracker _producerTrend = new TrendTracker(20);
+
+        public float ProducerFraction { get; private set; } = 1f;
+
+        public void Reset(EcosystemSimulation sim)
+        {
+            baselineProducers = Mathf.Max(1f, sim.GrazeableProducerBiomass());
+            level = HealthLevel.Green;
+            stage = CollapseStage.Healthy;
+            stageEnteredDay = 0;
+            ProducerFraction = 1f;
+            _producerTrend.Reset();
+        }
+
+        public void Evaluate(EcosystemSimulation sim)
+        {
+            float producers = sim.GrazeableProducerBiomass();
+            _producerTrend.Push(producers);
+
+            // A reef that grows past its old baseline resets the yardstick, so a
+            // recovered system is not judged against a peak it never had.
+            if (producers > baselineProducers) baselineProducers = producers;
+            ProducerFraction = producers / Mathf.Max(1f, baselineProducers);
+
+            var next = ClassifyStage(sim);
+            if (next != stage)
+            {
+                stage = next;
+                stageEnteredDay = sim.day;
+            }
+
+            level = stage switch
+            {
+                CollapseStage.Healthy     => HealthLevel.Green,
+                CollapseStage.Imbalance   => HealthLevel.Amber,
+                CollapseStage.Overgrazing => HealthLevel.Amber,
+                _                         => HealthLevel.Red,
+            };
+        }
+
+        CollapseStage ClassifyStage(EcosystemSimulation sim)
+        {
+            var all = SpeciesLibrary.All;
+            float fraction = ProducerFraction;
+
+            // Stage 5 — barren. Producers all but gone.
+            if (fraction < 0.12f) return CollapseStage.Barren;
+
+            // Stage 4 — collapse. Higher levels have lost their food.
+            bool huntersFailing = false;
+            for (int i = 0; i < all.Length; i++)
+            {
+                if (all[i].IsProducer || all[i].transient) continue;
+                if (all[i].level != TrophicLevel.Hunter) continue;
+                if (sim.IsPresent(i) && sim.pools[i].count <= 0f) huntersFailing = true;
+            }
+            if (fraction < 0.30f || (fraction < 0.55f && huntersFailing))
+                return CollapseStage.Collapse;
+
+            // Stage 3 — starvation. Somebody has been running an energy deficit.
+            int starving = 0;
+            for (int i = 0; i < all.Length; i++)
+            {
+                if (all[i].IsProducer || all[i].transient) continue;
+                if (sim.IsPresent(i) && sim.pools[i].daysHungry >= 5) starving++;
+            }
+            if (fraction < 0.55f || starving >= 2) return CollapseStage.Starvation;
+
+            // Stage 2 — overgrazing. Producer biomass is visibly falling.
+            if (fraction < 0.80f && _producerTrend.Direction < 0) return CollapseStage.Overgrazing;
+
+            // Stage 1 — imbalance. One population is climbing abnormally.
+            for (int i = 0; i < all.Length; i++)
+            {
+                if (all[i].IsProducer || all[i].transient) continue;
+                if (!sim.IsPresent(i)) continue;
+                if (sim.pools[i].count > all[i].startingStock * 1.9f)
+                    return CollapseStage.Imbalance;
+            }
+            if (fraction < 0.88f) return CollapseStage.Imbalance;
+
+            return CollapseStage.Healthy;
+        }
+
+        public static string Describe(CollapseStage stage) => stage switch
+        {
+            CollapseStage.Healthy     => "Balanced",
+            CollapseStage.Imbalance   => "Something is climbing",
+            CollapseStage.Overgrazing => "Being eaten faster than it grows",
+            CollapseStage.Starvation  => "Animals are starting to starve",
+            CollapseStage.Collapse    => "The food web is coming apart",
+            CollapseStage.Barren      => "Barren",
+            _ => "",
+        };
+
+        public static Color Colour(HealthLevel level) => level switch
+        {
+            HealthLevel.Green => new Color(0.24f, 0.72f, 0.36f),
+            HealthLevel.Amber => new Color(0.94f, 0.68f, 0.18f),
+            _                 => new Color(0.86f, 0.30f, 0.26f),
+        };
+    }
+
+    // A short rolling window, used for the trend arrows in the panel and for the
+    // "is it rising or falling" half of the reasoning rules.
+    public class TrendTracker
+    {
+        readonly float[] _values;
+        int _written;
+
+        public TrendTracker(int window)
+        {
+            _values = new float[Mathf.Max(2, window)];
+        }
+
+        public void Reset() => _written = 0;
+
+        public void Push(float value)
+        {
+            _values[_written % _values.Length] = value;
+            _written++;
+        }
+
+        public bool Ready => _written >= _values.Length;
+
+        public float Oldest =>
+            _written < _values.Length ? _values[0] : _values[_written % _values.Length];
+
+        public float Newest => _written == 0 ? 0f : _values[(_written - 1) % _values.Length];
+
+        // Fractional change across the window.
+        public float Change
+        {
+            get
+            {
+                if (_written < 2) return 0f;
+                float old = Oldest;
+                return Mathf.Abs(old) < 1e-4f ? 0f : (Newest - old) / old;
+            }
+        }
+
+        // -1 falling, 0 steady, +1 rising. The 4% dead band keeps the arrows from
+        // flickering on noise.
+        public int Direction
+        {
+            get
+            {
+                float c = Change;
+                if (c > 0.04f) return 1;
+                if (c < -0.04f) return -1;
+                return 0;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Sim/EcosystemHealth.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Sim/EcosystemHealth.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a80403a605412df449cd964de7734498

--- a/Assets/Scripts/LivingEcosystem/Sim/EcosystemSimulation.cs
+++ b/Assets/Scripts/LivingEcosystem/Sim/EcosystemSimulation.cs
@@ -1,0 +1,419 @@
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem
+{
+    // Each species is a small set of numbers, not a crowd of creatures
+    // (Design Document 3.1). The renderer draws a sample and scales it to the pool.
+    public struct Pool
+    {
+        public float biomass;     // total energy held, in kg over the patch
+        public float count;       // how many individuals (0 for producers)
+        public float energy;      // running energy balance, read by the Why panel
+        public float intake;      // biomass eaten this tick
+        public float demand;      // biomass wanted this tick
+        public float removed;     // biomass taken from this pool by predators this tick
+        public bool  bleached;    // producers only
+        public int   daysHungry;  // consecutive ticks with a negative energy balance
+    }
+
+    // The number-pool model. Plain arithmetic, one pass per simulated day, no
+    // pathfinding, no spatial partitioning, no jobs — everything on the main thread
+    // in microseconds (Design Document 3.1–3.3).
+    //
+    // The equations are the ones in the design document, with three additions that
+    // the design document's shape implies but does not spell out, and without which
+    // the web does not survive a session:
+    //
+    //   * a multi-prey Holling type II response, so feeding saturates when prey is
+    //     plentiful AND demand switches to what is actually there when it is not;
+    //   * a refuge per prey species, so predation fades before the prey is gone
+    //     instead of chasing the last individual to extinction;
+    //   * recruitment for producers, so a grazed-out alga can return once the
+    //     pressure lifts rather than being stuck at zero for ever.
+    //
+    // All three are ordinary reef ecology and all three are data, not code.
+    public class EcosystemSimulation
+    {
+        public readonly Pool[] pools = new Pool[SpeciesLibrary.Count];
+        public bool[] present = SpeciesLibrary.AllPresent();
+
+        public float detritus;
+        public int   day;
+        public float temperatureC = 24f;
+        public float acidityPh    = 8.1f;
+
+        // Seeded so a shared environment replays identically and bugs are
+        // reproducible (Design Document 3.2).
+        public int seed;
+        System.Random _rng;
+
+        readonly float[] _termScratch = new float[SpeciesLibrary.Count];
+        readonly float[] _linkWant = new float[SpeciesLibrary.Web.Length];
+
+        public EcosystemSimulation(EcosystemSettings settings, int seed = 0)
+        {
+            this.seed = seed;
+            _rng = new System.Random(seed);
+            Reset(settings);
+        }
+
+        public void Reset(EcosystemSettings settings)
+        {
+            settings?.Clamp();
+            day = 0;
+            detritus = 120f;
+            _rng = new System.Random(seed);
+
+            temperatureC = settings != null ? settings.temperatureC : 24f;
+            acidityPh    = settings != null ? settings.acidityPh : 8.1f;
+            present      = settings != null && settings.present != null
+                         ? (bool[])settings.present.Clone()
+                         : SpeciesLibrary.AllPresent();
+
+            float lifeScale = settings != null
+                ? EcosystemSettings.StartingLifeScale[Mathf.Clamp(settings.startingLife, 0, 2)]
+                : 1f;
+
+            var all = SpeciesLibrary.All;
+            for (int i = 0; i < all.Length; i++)
+            {
+                pools[i] = default;
+                if (!IsPresent(i)) continue;
+
+                var s = all[i];
+                if (s.IsProducer)
+                {
+                    pools[i].biomass = s.startingStock * lifeScale;
+                }
+                else
+                {
+                    // A transient visitor is present or it is not; "starting life"
+                    // does not make half a shark.
+                    pools[i].count = s.transient
+                        ? Mathf.Round(s.startingStock)
+                        : Mathf.Max(1f, s.startingStock * lifeScale);
+                    pools[i].biomass = pools[i].count * s.unitMass;
+                }
+            }
+        }
+
+        public bool IsPresent(int i) =>
+            present != null && i >= 0 && i < present.Length && present[i];
+
+        // Species whose individuals are simulated one at a time rather than as a
+        // number. Set by whoever owns those agents; nothing here needs to know what
+        // they are, only to leave their births and deaths alone.
+        public readonly bool[] agentManaged = new bool[SpeciesLibrary.Count];
+
+        public bool IsAgentManaged(int i) =>
+            i >= 0 && i < agentManaged.Length && agentManaged[i];
+
+        // Removing a species mid-scene is deliberately abrupt (Design Document 6.1).
+        public void SetPresent(int i, bool value)
+        {
+            if (present == null || i < 0 || i >= present.Length) return;
+            if (present[i] == value) return;
+
+            present[i] = value;
+            var s = SpeciesLibrary.Get(i);
+            if (s == null) return;
+
+            if (!value)
+            {
+                // Whatever was alive becomes detritus; the web reorganises around the gap.
+                detritus += pools[i].biomass * SpeciesLibrary.DetritusFromDeath;
+                pools[i] = default;
+            }
+            else
+            {
+                // Adding one back reintroduces it at a small founding population,
+                // which is itself instructive: recovery is slower than removal.
+                if (s.IsProducer)
+                    pools[i].biomass = s.startingStock * 0.15f;
+                else
+                {
+                    pools[i].count = s.transient ? 1f : Mathf.Max(1f, Mathf.Round(s.startingStock * 0.20f));
+                    pools[i].biomass = pools[i].count * s.unitMass;
+                }
+            }
+        }
+
+        public void Tick()
+        {
+            day++;
+            var all = SpeciesLibrary.All;
+            var web = SpeciesLibrary.Web;
+            float metabolic = EcosystemBounds.MetabolicFactor(temperatureC);
+
+            for (int i = 0; i < all.Length; i++)
+            {
+                pools[i].intake = 0f;
+                pools[i].removed = 0f;
+                pools[i].demand = 0f;
+            }
+            for (int k = 0; k < _linkWant.Length; k++)
+                _linkWant[k] = 0f;
+
+            // ── 1. Who wants what ────────────────────────────────────────────
+            // Two passes: everyone states a want, then short supply is shared out in
+            // proportion to demand. Allocating in array order instead would quietly
+            // let whichever species is evaluated first eat before the others.
+            float detritusWanted = 0f;
+            for (int c = 0; c < all.Length; c++)
+            {
+                if (!IsPresent(c) || pools[c].count <= 0f) continue;
+                var s = all[c];
+                if (s.IsProducer) continue;
+
+                float demand = pools[c].count * s.appetite * metabolic * Mathf.Max(0.01f, s.presence);
+                pools[c].demand = demand;
+                if (s.detritusFraction > 0f)
+                    detritusWanted += demand * s.detritusFraction;
+            }
+
+            float detritusScale = detritusWanted > 1e-6f
+                ? Mathf.Min(1f, detritus / detritusWanted)
+                : 0f;
+
+            for (int c = 0; c < all.Length; c++)
+            {
+                if (!IsPresent(c) || pools[c].count <= 0f) continue;
+                var s = all[c];
+                if (s.IsProducer) continue;
+
+                if (s.detritusFraction > 0f)
+                {
+                    float take = pools[c].demand * s.detritusFraction * detritusScale;
+                    pools[c].intake += take;
+                    detritus -= take;
+                }
+
+                float liveDemand = pools[c].demand * (1f - s.detritusFraction);
+                if (liveDemand <= 0f) continue;
+
+                // Multi-prey Holling type II (the disc equation). One expression gives
+                // both saturation — a full predator stops hunting — and switching:
+                // demand aimed at prey that has run out moves to prey that has not,
+                // instead of being thrown away on an empty larder.
+                float denom = 1f;
+                for (int k = 0; k < web.Length; k++)
+                {
+                    var link = web[k];
+                    if (link.predator != c) continue;
+                    int p = link.prey;
+                    _termScratch[p] = 0f;
+                    if (!IsPresent(p) || pools[p].biomass <= 1e-6f) continue;
+
+                    var preyDef = all[p];
+                    float reachable = Mathf.Max(0f, pools[p].biomass - preyDef.refuge);
+                    if (reachable <= 0f) continue;
+
+                    float term = link.preference * reachable / Mathf.Max(0.01f, link.halfSaturation);
+                    _termScratch[p] = term;
+                    denom += term;
+                }
+
+                for (int k = 0; k < web.Length; k++)
+                {
+                    var link = web[k];
+                    if (link.predator != c) continue;
+                    float term = _termScratch[link.prey];
+                    if (term <= 0f) continue;
+
+                    float want = liveDemand * term / denom;
+                    _linkWant[k] = want;
+                    pools[link.prey].removed += want;
+                }
+            }
+
+            // Nothing may be eaten twice: where several predators claim the same pool,
+            // scale every claim back to what is actually there, then hand each
+            // predator only what it really got.
+            for (int k = 0; k < web.Length; k++)
+            {
+                float want = _linkWant[k];
+                if (want <= 0f) continue;
+
+                var link = web[k];
+                float claimed = pools[link.prey].removed;
+                float scale = claimed > pools[link.prey].biomass && claimed > 0f
+                    ? pools[link.prey].biomass / claimed
+                    : 1f;
+
+                pools[link.predator].intake += want * scale;
+            }
+
+            for (int p = 0; p < all.Length; p++)
+                pools[p].removed = Mathf.Min(pools[p].removed, pools[p].biomass);
+
+            // ── 2. Producers ─────────────────────────────────────────────────
+            for (int i = 0; i < all.Length; i++)
+            {
+                var s = all[i];
+                if (!s.IsProducer) continue;
+                if (!IsPresent(i)) { pools[i] = default; continue; }
+
+                float capacity = s.baseCapacity
+                               * EcosystemBounds.Light
+                               * EcosystemBounds.TemperatureFactor(temperatureC, s.optimumTemperature, s.temperatureTolerance)
+                               * EcosystemBounds.CalcificationFactor(acidityPh, s.calcifierWeight);
+                capacity = Mathf.Max(1f, capacity);
+
+                float rate = s.growthRate;
+                float lossRate = s.naturalLoss;
+
+                // Bleaching: above its threshold the coral expels the symbionts that
+                // supply most of its energy. It is not dead, and it recovers if the
+                // water cools, but it grows barely at all and wastes away meanwhile.
+                pools[i].bleached = false;
+                if (s.CanBleach && temperatureC > s.bleachingThresholdC)
+                {
+                    float severity = Mathf.Clamp01((temperatureC - s.bleachingThresholdC) / 2.5f);
+                    rate *= 1f - 0.85f * severity;
+                    lossRate *= 1f + 3f * severity;
+                    pools[i].bleached = true;
+                }
+
+                float biomass = pools[i].biomass;
+                float growth = rate * biomass * (1f - biomass / capacity);
+
+                // Spore and drift recruitment from the surrounding reef.
+                if (biomass < capacity * 0.05f)
+                    growth += s.recruitment * capacity;
+
+                float loss = lossRate * biomass;
+                float grazed = pools[i].removed;
+
+                biomass += growth - grazed - loss;
+                pools[i].biomass = Mathf.Max(0f, biomass);
+
+                // The detritus loop: decomposition returning nutrients to the base.
+                detritus += loss * SpeciesLibrary.DetritusFromDeath
+                          + grazed * SpeciesLibrary.DetritusFromGrazing;
+            }
+
+            // ── 3. Consumers ─────────────────────────────────────────────────
+            for (int c = 0; c < all.Length; c++)
+            {
+                var s = all[c];
+                if (s.IsProducer) continue;
+                if (!IsPresent(c)) { pools[c] = default; continue; }
+
+                if (s.transient)
+                {
+                    // A transient apex predator is present or it is not. It does not
+                    // breed here and it does not starve here — it swims elsewhere.
+                    pools[c].count = 1f;
+                    pools[c].biomass = s.unitMass;
+                    pools[c].energy = 0f;
+                    pools[c].daysHungry = 0;
+                    continue;
+                }
+
+                if (pools[c].count <= 0f) continue;
+
+                float gain = pools[c].intake * s.assimilation;
+                float cost = pools[c].count * s.livingCost * metabolic;
+
+                // Energy is kept as a running balance because the reasoning rules read
+                // it ("consumer energy negative for 5+ days -> starvation"), while
+                // births and deaths run off the supply/need ratio, which responds at once.
+                pools[c].energy += gain - cost;
+                pools[c].energy = Mathf.Clamp(pools[c].energy, -cost * 12f, cost * 12f);
+                pools[c].daysHungry = gain < cost ? pools[c].daysHungry + 1 : 0;
+
+                float ratio = cost > 1e-9f ? gain / cost : (gain > 0f ? 2f : 0f);
+
+                // A species that has been promoted to individual agents stops here.
+                // The pool still states its demand, takes its intake and suffers its
+                // predation — so the food web around it is exactly the web that was
+                // balanced — but who eats, who breeds and who dies is decided one
+                // animal at a time by the agent layer, which writes the count back.
+                if (IsAgentManaged(c)) continue;
+
+                if (ratio >= 1f)
+                {
+                    float surplus = Mathf.Min(1f, (ratio - 1f) / SpeciesLibrary.SurplusForFullBreeding);
+                    float room = Mathf.Max(0f, 1f - pools[c].count / Mathf.Max(1f, s.ceiling));
+                    pools[c].count += pools[c].count * s.birthRate * surplus * room;
+                }
+                else
+                {
+                    float deficit = Mathf.Min(1f, (1f - ratio) / SpeciesLibrary.DeficitForFullDeath);
+                    float deaths = pools[c].count * s.starveRate * deficit;
+                    pools[c].count -= deaths;
+                    detritus += deaths * s.unitMass * SpeciesLibrary.DetritusFromDeath;
+                }
+
+                // Predation removal, converted from biomass back into individuals.
+                if (pools[c].removed > 0f && s.unitMass > 1e-6f)
+                {
+                    pools[c].count = Mathf.Max(0f, pools[c].count - pools[c].removed / s.unitMass);
+                    detritus += pools[c].removed * 0.15f;
+                }
+
+                pools[c].count = Mathf.Clamp(pools[c].count, 0f, s.ceiling * 1.15f);
+                if (pools[c].count < 0.35f)
+                {
+                    pools[c].count = 0f;
+                    pools[c].energy = 0f;
+                }
+                pools[c].biomass = pools[c].count * s.unitMass;
+            }
+
+            // Bacteria return nutrients to the water; energy is genuinely lost at each
+            // step and cannot be recycled, but nutrients are used again and again.
+            detritus = Mathf.Max(0f, detritus * (1f - SpeciesLibrary.DetritusRemineralised));
+        }
+
+        // ── Readouts ─────────────────────────────────────────────────────────
+        public float DisplayAmount(int i)
+        {
+            var s = SpeciesLibrary.Get(i);
+            if (s == null) return 0f;
+            return s.IsProducer ? pools[i].biomass : pools[i].count;
+        }
+
+        public bool IsAlive(int i) => IsPresent(i) && DisplayAmount(i) > 0.05f;
+
+        // Total biomass at each trophic level, for the energy pyramid.
+        public float BiomassAtLevel(TrophicLevel level)
+        {
+            float total = 0f;
+            var all = SpeciesLibrary.All;
+            for (int i = 0; i < all.Length; i++)
+                if (all[i].level == level && IsPresent(i))
+                    total += pools[i].biomass;
+            return total;
+        }
+
+        public float TotalProducerBiomass() => BiomassAtLevel(TrophicLevel.Producer);
+
+        // Producer biomass that something actually eats.
+        //
+        // The coral is a producer but is not grazed in this model, and it is the
+        // slowest-growing thing here — so it survives a collapse almost untouched.
+        // Judging the reef's health on total producer biomass would let the coral
+        // mask a seafloor grazed down to bare rock, and the barren stage could never
+        // be reached. Health is measured against the part of the base that is
+        // actually under pressure.
+        public float GrazeableProducerBiomass()
+        {
+            float total = 0f;
+            var all = SpeciesLibrary.All;
+            var web = SpeciesLibrary.Web;
+
+            for (int i = 0; i < all.Length; i++)
+            {
+                if (!all[i].IsProducer || !IsPresent(i)) continue;
+
+                bool grazed = false;
+                for (int k = 0; k < web.Length; k++)
+                    if (web[k].prey == i) { grazed = true; break; }
+
+                if (grazed) total += pools[i].biomass;
+            }
+            return total;
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Sim/EcosystemSimulation.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Sim/EcosystemSimulation.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fc2dd3e3b92cb8142b1bbf9209896e8c

--- a/Assets/Scripts/LivingEcosystem/Sim/RewindBuffer.cs
+++ b/Assets/Scripts/LivingEcosystem/Sim/RewindBuffer.cs
@@ -1,0 +1,98 @@
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem
+{
+    // A lightweight snapshot of the pool state, written every 30 simulated days,
+    // last three retained. Well under 1 KB, and it gives the learner a way back
+    // without punishing experimentation (Design Document 6.3).
+    public class RewindBuffer
+    {
+        public const int IntervalDays = 30;
+        public const int Capacity = 3;
+
+        public class Snapshot
+        {
+            public int day;
+            public float detritus;
+            public float[] biomass;
+            public float[] count;
+            public bool[] present;
+            public float temperatureC;
+            public float acidityPh;
+        }
+
+        readonly Snapshot[] _slots = new Snapshot[Capacity];
+        int _written;
+        int _lastCaptureDay = -IntervalDays;
+
+        public int StoredCount => Mathf.Min(_written, Capacity);
+        public bool HasAny => StoredCount > 0;
+
+        public void Reset()
+        {
+            _written = 0;
+            _lastCaptureDay = -IntervalDays;
+            for (int i = 0; i < _slots.Length; i++) _slots[i] = null;
+        }
+
+        public void MaybeCapture(EcosystemSimulation sim)
+        {
+            if (sim.day - _lastCaptureDay < IntervalDays) return;
+            _lastCaptureDay = sim.day;
+            Capture(sim);
+        }
+
+        public void Capture(EcosystemSimulation sim)
+        {
+            int n = SpeciesLibrary.Count;
+            var snap = new Snapshot
+            {
+                day = sim.day,
+                detritus = sim.detritus,
+                biomass = new float[n],
+                count = new float[n],
+                present = new bool[n],
+                temperatureC = sim.temperatureC,
+                acidityPh = sim.acidityPh,
+            };
+            for (int i = 0; i < n; i++)
+            {
+                snap.biomass[i] = sim.pools[i].biomass;
+                snap.count[i] = sim.pools[i].count;
+                snap.present[i] = sim.IsPresent(i);
+            }
+            _slots[_written % Capacity] = snap;
+            _written++;
+        }
+
+        // The most recent snapshot, or null when nothing has been captured yet.
+        public Snapshot Latest =>
+            _written == 0 ? null : _slots[(_written - 1) % Capacity];
+
+        // Restores the reef to a previous day. Returns the snapshot used, or null.
+        public Snapshot Restore(EcosystemSimulation sim)
+        {
+            var snap = Latest;
+            if (snap == null) return null;
+
+            for (int i = 0; i < SpeciesLibrary.Count; i++)
+            {
+                sim.pools[i] = default;
+                sim.pools[i].biomass = snap.biomass[i];
+                sim.pools[i].count = snap.count[i];
+                if (sim.present != null && i < sim.present.Length)
+                    sim.present[i] = snap.present[i];
+            }
+            sim.detritus = snap.detritus;
+            sim.day = snap.day;
+            sim.temperatureC = snap.temperatureC;
+            sim.acidityPh = snap.acidityPh;
+
+            // Consume it, so repeated presses walk further back rather than sticking.
+            _slots[(_written - 1) % Capacity] = null;
+            _written--;
+            _lastCaptureDay = snap.day;
+            return snap;
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/Sim/RewindBuffer.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/Sim/RewindBuffer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3db069cebbcd43b4e85eb0cba40c1cf3

--- a/Assets/Scripts/LivingEcosystem/UI.meta
+++ b/Assets/Scripts/LivingEcosystem/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 13df5ea406596c44ea4d934939b73f63
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/LivingEcosystem/UI/BarrenPromptUI.cs
+++ b/Assets/Scripts/LivingEcosystem/UI/BarrenPromptUI.cs
@@ -1,0 +1,135 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace CreateEnv.Ecosystem.UI
+{
+    // The barren-state prompt (Design Document 6.3).
+    //
+    // At the barren stage the app offers three options: restore the missing species
+    // and watch recovery, rewind to the last healthy day, or start again. Recovery
+    // deliberately takes longer than the collapse did — which is the most important
+    // single lesson the feature can deliver, so the card says so out loud.
+    //
+    // Shown once per collapse. If the learner dismisses it and the reef falls apart
+    // again later, it returns.
+    public class BarrenPromptUI : MonoBehaviour
+    {
+        LivingReefController _reef;
+        GameObject _root;
+        TMP_Text _body;
+        Button _rewindButton;
+        bool _shownForThisCollapse;
+
+        public static BarrenPromptUI Create(Transform parent, LivingReefController reef)
+        {
+            var host = EcoUIKit.Empty(parent, "BarrenPrompt");
+            EcoUIKit.Stretch(EcoUIKit.Rect(host), 0f, 0f);
+
+            var ui = host.AddComponent<BarrenPromptUI>();
+            ui._reef = reef;
+            ui.Build(host.transform);
+            return ui;
+        }
+
+        void Build(Transform parent)
+        {
+            var scrim = EcoUIKit.Panel(parent, "Scrim", new Color(0f, 0f, 0f, 0.72f));
+            EcoUIKit.Stretch(EcoUIKit.Rect(scrim), 0f, 0f);
+
+            var card = EcoUIKit.Panel(scrim.transform, "Card", EcoUIKit.PanelBgSoft);
+            var cardRect = EcoUIKit.Rect(card);
+            cardRect.anchorMin = new Vector2(0.5f, 0.5f);
+            cardRect.anchorMax = new Vector2(0.5f, 0.5f);
+            cardRect.pivot = new Vector2(0.5f, 0.5f);
+            cardRect.sizeDelta = new Vector2(860f, 720f);
+
+            var title = EcoUIKit.Text(card.transform, "Your reef is barren", 36f,
+                                      new Color(0.90f, 0.46f, 0.42f));
+            var titleRect = EcoUIKit.Rect(title.gameObject);
+            titleRect.anchorMin = new Vector2(0f, 1f);
+            titleRect.anchorMax = new Vector2(1f, 1f);
+            titleRect.pivot = new Vector2(0.5f, 1f);
+            titleRect.sizeDelta = new Vector2(-64f, 52f);
+            titleRect.anchoredPosition = new Vector2(0f, -32f);
+
+            _body = EcoUIKit.Text(card.transform, "", 25f, EcoUIKit.TextMain);
+            var bodyRect = EcoUIKit.Rect(_body.gameObject);
+            bodyRect.anchorMin = new Vector2(0f, 0f);
+            bodyRect.anchorMax = new Vector2(1f, 1f);
+            bodyRect.offsetMin = new Vector2(40f, 260f);
+            bodyRect.offsetMax = new Vector2(-40f, -100f);
+
+            float y = 190f;
+            MakeButton(card.transform, "Put the missing species back", ref y, EcoUIKit.Accent, () =>
+            {
+                _reef.RestoreAllSpecies();
+                Close();
+            });
+
+            _rewindButton = MakeButton(card.transform, "Rewind to the last healthy day", ref y,
+                                       EcoUIKit.Track, () =>
+            {
+                _reef.Rewind();
+                Close();
+            });
+
+            MakeButton(card.transform, "Start this reef again", ref y, EcoUIKit.Track, () =>
+            {
+                _reef.RestartEcosystem();
+                Close();
+            });
+
+            var dismiss = EcoUIKit.Button(card.transform, "Leave it as it is", 22f,
+                                          new Color(0f, 0f, 0f, 0f), EcoUIKit.TextDim, Close);
+            var dismissRect = EcoUIKit.Rect(dismiss.gameObject);
+            dismissRect.anchorMin = new Vector2(0.5f, 0f);
+            dismissRect.anchorMax = new Vector2(0.5f, 0f);
+            dismissRect.pivot = new Vector2(0.5f, 0f);
+            dismissRect.sizeDelta = new Vector2(420f, 46f);
+            dismissRect.anchoredPosition = new Vector2(0f, 16f);
+
+            _root = scrim;
+            _root.SetActive(false);
+        }
+
+        Button MakeButton(Transform parent, string label, ref float y, Color colour, System.Action action)
+        {
+            var button = EcoUIKit.Button(parent, label, 25f, colour,
+                                         colour == EcoUIKit.Accent ? Color.white : EcoUIKit.TextMain,
+                                         action);
+            var rect = EcoUIKit.Rect(button.gameObject);
+            rect.anchorMin = new Vector2(0.5f, 0f);
+            rect.anchorMax = new Vector2(0.5f, 0f);
+            rect.pivot = new Vector2(0.5f, 0f);
+            rect.sizeDelta = new Vector2(760f, 62f);
+            rect.anchoredPosition = new Vector2(0f, y);
+            y -= 72f;
+            return button;
+        }
+
+        // Called every frame while the reef is barren; shows itself once.
+        public void MaybeShow()
+        {
+            if (_shownForThisCollapse || _root.activeSelf) return;
+            _shownForThisCollapse = true;
+
+            bool canRewind = _reef.CanRewind;
+            _rewindButton.gameObject.SetActive(canRewind);
+            _rewindButton.interactable = canRewind;
+
+            _body.text =
+                "Only detritus and the slowest-growing survivors are left.\n\n" +
+                "This is what a collapsed reef looks like. Putting the missing species back " +
+                "will start a recovery, but it will take far longer than the collapse did — " +
+                "an ecosystem is much quicker to break than to rebuild.";
+
+            _root.SetActive(true);
+        }
+
+        // Re-arms once the reef has recovered, so a second collapse prompts again.
+        public void NotifyRecovered() => _shownForThisCollapse = false;
+
+        public void Close() => _root.SetActive(false);
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/UI/BarrenPromptUI.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/UI/BarrenPromptUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 360fb0a4dd9c30e4789ae7efdfcf9069

--- a/Assets/Scripts/LivingEcosystem/UI/BreedingToolUI.cs
+++ b/Assets/Scripts/LivingEcosystem/UI/BreedingToolUI.cs
@@ -1,0 +1,341 @@
+using System.Collections.Generic;
+using System.Text;
+using CreateEnv.Ecosystem.Genetics;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace CreateEnv.Ecosystem.UI
+{
+    // The breeding tool: pick two octopuses, see the prediction, breed them, compare
+    // the result (Milestone Step 2, Breeding tool).
+    //
+    // The prediction comes from PunnettPrediction, which derives it from the same
+    // rule Genome.Inherit actually uses, so the grid cannot drift away from the maths
+    // underneath it.
+    //
+    // The lesson hidden in the tool is the mismatch: a grid predicts ratios over many
+    // offspring, and a brood of two to four will frequently not match. Letting the
+    // learner see that teaches more about probability than a tidy result would, so
+    // the tool says it in advance and then shows what actually happened.
+    public class BreedingToolUI : MonoBehaviour
+    {
+        LivingReefController _reef;
+        GameObject _root;
+        TMP_Text _title, _body;
+        RectTransform _content;
+        Button _actionButton;
+
+        int _motherId = -1, _fatherId = -1;
+        string _outcome;
+
+        public static BreedingToolUI Create(Transform parent, LivingReefController reef)
+        {
+            var host = EcoUIKit.Empty(parent, "BreedingTool");
+            EcoUIKit.Stretch(EcoUIKit.Rect(host), 0f, 0f);
+
+            var ui = host.AddComponent<BreedingToolUI>();
+            ui._reef = reef;
+            ui.Build(host.transform);
+            return ui;
+        }
+
+        void Build(Transform parent)
+        {
+            var scrim = EcoUIKit.Panel(parent, "Scrim", new Color(0f, 0f, 0f, 0.66f));
+            EcoUIKit.Stretch(EcoUIKit.Rect(scrim), 0f, 0f);
+
+            var card = EcoUIKit.Panel(scrim.transform, "Card", EcoUIKit.PanelBgSoft);
+            var cardRect = EcoUIKit.Rect(card);
+            cardRect.anchorMin = new Vector2(0.5f, 0.5f);
+            cardRect.anchorMax = new Vector2(0.5f, 0.5f);
+            cardRect.pivot = new Vector2(0.5f, 0.5f);
+            cardRect.sizeDelta = new Vector2(920f, 1320f);
+
+            _title = EcoUIKit.Text(card.transform, "Breeding", 34f, EcoUIKit.TextMain);
+            var titleRect = EcoUIKit.Rect(_title.gameObject);
+            titleRect.anchorMin = new Vector2(0f, 1f);
+            titleRect.anchorMax = new Vector2(1f, 1f);
+            titleRect.pivot = new Vector2(0.5f, 1f);
+            titleRect.sizeDelta = new Vector2(-60f, 48f);
+            titleRect.anchoredPosition = new Vector2(0f, -26f);
+
+            var scrollHost = EcoUIKit.Empty(card.transform, "Scroll");
+            var scrollRect = EcoUIKit.Rect(scrollHost);
+            scrollRect.anchorMin = Vector2.zero;
+            scrollRect.anchorMax = Vector2.one;
+            scrollRect.offsetMin = new Vector2(40f, 182f);
+            scrollRect.offsetMax = new Vector2(-40f, -100f);
+
+            _content = EcoUIKit.ScrollColumn(scrollHost.transform, out _);
+            EcoUIKit.Stretch(EcoUIKit.Rect(_content.parent.gameObject), 0f, 0f);
+
+            _body = EcoUIKit.Text(_content, "", 23f, EcoUIKit.TextMain);
+            _body.gameObject.AddComponent<LayoutElement>().minHeight = 60f;
+            var fitter = _body.gameObject.AddComponent<ContentSizeFitter>();
+            fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+
+            _actionButton = EcoUIKit.Button(card.transform, "Breed them", 26f,
+                                            EcoUIKit.Accent, Color.white, Breed);
+            var actionRect = EcoUIKit.Rect(_actionButton.gameObject);
+            actionRect.anchorMin = new Vector2(0f, 0f);
+            actionRect.anchorMax = new Vector2(1f, 0f);
+            actionRect.pivot = new Vector2(0.5f, 0f);
+            actionRect.sizeDelta = new Vector2(-60f, 60f);
+            actionRect.anchoredPosition = new Vector2(0f, 92f);
+
+            var close = EcoUIKit.Button(card.transform, "Close", 24f, EcoUIKit.Track,
+                                        EcoUIKit.TextMain, Close);
+            var closeRect = EcoUIKit.Rect(close.gameObject);
+            closeRect.anchorMin = new Vector2(0.5f, 0f);
+            closeRect.anchorMax = new Vector2(0.5f, 0f);
+            closeRect.pivot = new Vector2(0.5f, 0f);
+            closeRect.sizeDelta = new Vector2(320f, 54f);
+            closeRect.anchoredPosition = new Vector2(0f, 24f);
+
+            _root = scrim;
+            _root.SetActive(false);
+        }
+
+        public void Close()
+        {
+            _root.SetActive(false);
+            // Stop lighting them once the learner has left the tool; a brooding
+            // female keeps her own glow from the renderer.
+            _reef.chosenFemaleId = -1;
+            _reef.chosenMaleId = -1;
+        }
+
+        void PushSelection()
+        {
+            _reef.chosenFemaleId = _motherId;
+            _reef.chosenMaleId = _fatherId;
+        }
+
+        // Opens with one parent already chosen; the other is picked from the list.
+        public void Open(int firstParentId)
+        {
+            var pop = _reef.Octopuses;
+            if (pop == null) return;
+
+            var first = pop.ById(firstParentId);
+            _motherId = _fatherId = -1;
+            if (first != null)
+            {
+                if (first.sex == Sex.Female) _motherId = first.id;
+                else _fatherId = first.id;
+            }
+
+            _outcome = null;
+            PushSelection();
+            Refresh();
+            _root.SetActive(true);
+        }
+
+        void Refresh()
+        {
+            var pop = _reef.Octopuses;
+            var mother = _motherId >= 0 ? pop.ById(_motherId) : null;
+            var father = _fatherId >= 0 ? pop.ById(_fatherId) : null;
+
+            _title.text = "Breeding";
+
+            var sb = new StringBuilder();
+
+            if (_outcome != null)
+            {
+                // The card already has a Close at the bottom. Turning the action
+                // button into a second one just asks the learner which Close to press.
+                _actionButton.gameObject.SetActive(false);
+                sb.Append(_outcome);
+                _body.text = sb.ToString();
+                return;
+            }
+
+            _actionButton.gameObject.SetActive(true);
+
+            // ── Who is chosen ────────────────────────────────────────────────
+            sb.Append("<b>The pair</b>\n");
+            sb.Append("Mother: ").Append(mother != null ? $"{mother.name}  ({mother.genome.Notation()})" : "— choose below —").Append('\n');
+            sb.Append("Father: ").Append(father != null ? $"{father.name}  ({father.genome.Notation()})" : "— choose below —").Append("\n\n");
+
+            if (mother == null || father == null)
+            {
+                sb.Append("<b>Choose the other parent</b>\n");
+                sb.Append("<color=#9FB2C4>Both must be mature, and one of each sex.</color>\n\n");
+                BuildCandidateButtons(mother == null ? Sex.Female : Sex.Male);
+                SetAction("Breed them", Breed, false);
+                _body.text = sb.ToString();
+                return;
+            }
+
+            ClearCandidates();
+
+            // ── The prediction ───────────────────────────────────────────────
+            sb.Append("<b>What their young could inherit</b>\n\n");
+
+            foreach (GeneId gene in System.Enum.GetValues(typeof(GeneId)))
+            {
+                sb.Append("<b>").Append(Genome.NameOf(gene)).Append("</b>   ")
+                  .Append(mother.genome.Notation(gene)).Append("  x  ")
+                  .Append(father.genome.Notation(gene)).Append('\n');
+
+                sb.Append(GridArt(mother.genome, father.genome, gene));
+
+                foreach (var outcome in PunnettPrediction.Outcomes(mother.genome, father.genome, gene))
+                {
+                    sb.Append("   ").Append(outcome.notation).Append("  ")
+                      .Append(Mathf.RoundToInt(outcome.probability * 100f)).Append("%   ")
+                      .Append("<color=#9FB2C4>").Append(outcome.phenotype).Append("</color>\n");
+                }
+                sb.Append("   ratio ").Append(PunnettPrediction.RatioText(mother.genome, father.genome, gene))
+                  .Append("\n\n");
+            }
+
+            sb.Append("<color=#9FB2C4>").Append(PunnettPrediction.SmallBroodCaveat).Append("</color>\n\n");
+            sb.Append("<color=#C27A14>Both parents die after breeding. This is real, and it is " +
+                      "what makes an octopus generation short enough to watch.</color>");
+
+            SetAction("Breed them", Breed, true);
+            _body.text = sb.ToString();
+        }
+
+        // The classic two-by-two, drawn in text so it reads on any screen width.
+        static string GridArt(Genome mother, Genome father, GeneId gene)
+        {
+            char upper = Genome.LetterOf(gene);
+            char lower = char.ToLowerInvariant(upper);
+
+            string Allele(Genome g, int copy) => g.Allele(gene, copy) ? upper.ToString() : lower.ToString();
+
+            string f0 = Allele(father, 0), f1 = Allele(father, 1);
+            string m0 = Allele(mother, 0), m1 = Allele(mother, 1);
+
+            string Cell(string a, string b)
+            {
+                // Always written uppercase-first, so the same genotype always reads
+                // the same way.
+                bool aUpper = a[0] == upper;
+                bool bUpper = b[0] == upper;
+                return aUpper == bUpper ? a + b : upper.ToString() + lower.ToString();
+            }
+
+            var sb = new StringBuilder();
+            sb.Append("<color=#9FB2C4><mspace=1.1em>");
+            sb.Append("      ").Append(f0).Append("   ").Append(f1).Append('\n');
+            sb.Append("   ").Append(m0).Append("  ").Append(Cell(m0, f0)).Append("  ").Append(Cell(m0, f1)).Append('\n');
+            sb.Append("   ").Append(m1).Append("  ").Append(Cell(m1, f0)).Append("  ").Append(Cell(m1, f1)).Append('\n');
+            sb.Append("</mspace></color>");
+            return sb.ToString();
+        }
+
+        readonly List<GameObject> _candidates = new List<GameObject>(8);
+
+        void ClearCandidates()
+        {
+            for (int i = 0; i < _candidates.Count; i++)
+                if (_candidates[i] != null) Destroy(_candidates[i]);
+            _candidates.Clear();
+        }
+
+        void BuildCandidateButtons(Sex wanted)
+        {
+            ClearCandidates();
+            var pop = _reef.Octopuses;
+            if (pop == null) return;
+
+            foreach (var a in pop.agents)
+            {
+                if (!a.IsAlive || a.sex != wanted) continue;
+                if (!a.IsMature(OctopusPopulation.MaturityDays) || a.IsBrooding) continue;
+
+                int id = a.id;
+                var button = EcoUIKit.Button(_content, $"{a.name}   {a.genome.Notation()}", 23f,
+                                             EcoUIKit.Track, EcoUIKit.TextMain,
+                                             () =>
+                                             {
+                                                 if (wanted == Sex.Female) _motherId = id;
+                                                 else _fatherId = id;
+                                                 PushSelection();
+                                                 Refresh();
+                                             });
+                button.gameObject.AddComponent<LayoutElement>().preferredHeight = 56f;
+                _candidates.Add(button.gameObject);
+            }
+
+            if (_candidates.Count == 0)
+            {
+                var none = EcoUIKit.Text(_content,
+                    wanted == Sex.Female
+                        ? "No mature female is available right now."
+                        : "No mature male is available right now.",
+                    22f, new Color(0.96f, 0.76f, 0.36f));
+                none.gameObject.AddComponent<LayoutElement>().preferredHeight = 50f;
+                _candidates.Add(none.gameObject);
+            }
+        }
+
+        void SetAction(string label, System.Action action, bool enabled)
+        {
+            var text = _actionButton.GetComponentInChildren<TMP_Text>();
+            if (text != null) text.text = label;
+            _actionButton.interactable = enabled;
+            _actionButton.onClick.RemoveAllListeners();
+            if (action != null) _actionButton.onClick.AddListener(() => action());
+        }
+
+        void Breed()
+        {
+            var pop = _reef.Octopuses;
+            var mother = pop?.ById(_motherId);
+            var father = pop?.ById(_fatherId);
+            if (mother == null || father == null) return;
+
+            // Record what was predicted before the dice are rolled, so the comparison
+            // afterwards is honest.
+            var predicted = new Dictionary<GeneId, List<PunnettPrediction.Outcome>>();
+            foreach (GeneId gene in System.Enum.GetValues(typeof(GeneId)))
+                predicted[gene] = PunnettPrediction.Outcomes(mother.genome, father.genome, gene);
+
+            string motherName = mother.name, fatherName = father.name;
+            int generation = mother.generation + 1;
+
+            if (!pop.StartBrood(mother, father, _reef.Sim, SpeciesLibrary.Get(SpeciesLibrary.Octopus)))
+            {
+                _outcome = "They could not breed. Both must be mature, and she must not already be brooding.";
+                Refresh();
+                return;
+            }
+
+            var sb = new StringBuilder();
+            sb.Append("<size=115%><b>").Append(motherName).Append(" and ").Append(fatherName)
+              .Append(" have mated</b></size>\n\n");
+
+            sb.Append(motherName).Append(" has gone to her den. She will guard her eggs for about a " +
+                      "month and will not eat at all while she does — and within days of them " +
+                      "hatching, she dies. ").Append(fatherName)
+              .Append(" is already fading.\n\n");
+
+            sb.Append("<b>Watch for generation ").Append(generation).Append("</b>\n");
+            sb.Append("Tap one of the young when they hatch and see what it inherited.\n\n");
+
+            sb.Append("<b>You predicted</b>\n");
+            foreach (var pair in predicted)
+            {
+                sb.Append("<color=#9FB2C4>").Append(Genome.NameOf(pair.Key)).Append("</color>   ");
+                for (int i = 0; i < pair.Value.Count; i++)
+                {
+                    if (i > 0) sb.Append(" · ");
+                    sb.Append(pair.Value[i].notation).Append(' ')
+                      .Append(Mathf.RoundToInt(pair.Value[i].probability * 100f)).Append('%');
+                }
+                sb.Append('\n');
+            }
+            sb.Append("\n<color=#9FB2C4>A brood of two to four often will not match those numbers. " +
+                      "That is chance, not a mistake.</color>");
+
+            _outcome = sb.ToString();
+            Refresh();
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/UI/BreedingToolUI.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/UI/BreedingToolUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1e059b2c68909404da407a95d9070a35

--- a/Assets/Scripts/LivingEcosystem/UI/EcoToast.cs
+++ b/Assets/Scripts/LivingEcosystem/UI/EcoToast.cs
@@ -1,0 +1,91 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace CreateEnv.Ecosystem.UI
+{
+    // A line of text that appears near the bottom of the screen, waits, and goes.
+    //
+    // For the one thing a learner needs told and does not need to act on: where their
+    // report was saved. A dialog would demand a tap to dismiss for information that is
+    // over as soon as it is read, and on Android the share sheet has already covered
+    // the screen by then — so this sits low, above the thumb, and leaves on its own.
+    //
+    // Deliberately not Android's native Toast. This one shows in the Editor too, which
+    // is where the report is tested.
+    public class EcoToast : MonoBehaviour
+    {
+        const float FadeSeconds = 0.22f;
+
+        CanvasGroup _group;
+        TMP_Text _label;
+        RectTransform _card;
+        float _hold;
+
+        public static EcoToast Create(Transform parent)
+        {
+            var host = EcoUIKit.Empty(parent, "Toast");
+            EcoUIKit.Stretch(EcoUIKit.Rect(host), 0f, 0f);
+
+            var toast = host.AddComponent<EcoToast>();
+            toast.Build(host.transform);
+            return toast;
+        }
+
+        void Build(Transform parent)
+        {
+            var card = EcoUIKit.Panel(parent, "Card", new Color(0.06f, 0.10f, 0.14f, 0.96f));
+            _card = EcoUIKit.Rect(card);
+            _card.anchorMin = new Vector2(0.5f, 0f);
+            _card.anchorMax = new Vector2(0.5f, 0f);
+            _card.pivot = new Vector2(0.5f, 0f);
+            _card.sizeDelta = new Vector2(880f, 96f);
+            _card.anchoredPosition = new Vector2(0f, 150f);
+
+            _label = EcoUIKit.Text(card.transform, "", 24f, EcoUIKit.TextMain,
+                                   TextAlignmentOptions.Center);
+            _label.textWrappingMode = TextWrappingModes.Normal;
+            EcoUIKit.Stretch(EcoUIKit.Rect(_label.gameObject), 30f, 16f);
+
+            _group = card.AddComponent<CanvasGroup>();
+            _group.alpha = 0f;
+            // Nothing here is tappable, and a full-width strip that swallowed taps
+            // would block the reef underneath it for as long as it was on screen.
+            _group.blocksRaycasts = false;
+            _group.interactable = false;
+        }
+
+        public void Show(string message, float seconds = 4.5f)
+        {
+            if (string.IsNullOrEmpty(message)) return;
+
+            _label.text = message;
+
+            // Grown to fit, so a long file name is not clipped and a short one is not
+            // marooned in a wide empty bar.
+            float height = Mathf.Clamp(_label.GetPreferredValues(message, 820f, 0f).y + 32f,
+                                       78f, 220f);
+            _card.sizeDelta = new Vector2(880f, height);
+
+            _hold = seconds;
+            enabled = true;
+        }
+
+        void Update()
+        {
+            if (_hold > 0f)
+            {
+                _hold -= Time.unscaledDeltaTime;
+                _group.alpha = Mathf.MoveTowards(_group.alpha, 1f,
+                                                 Time.unscaledDeltaTime / FadeSeconds);
+                return;
+            }
+
+            _group.alpha = Mathf.MoveTowards(_group.alpha, 0f,
+                                             Time.unscaledDeltaTime / FadeSeconds);
+
+            // Nothing left to fade: stop taking a frame every frame.
+            if (_group.alpha <= 0f) enabled = false;
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/UI/EcoToast.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/UI/EcoToast.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 54ea3fb839e7a9d498abd26416ffd146

--- a/Assets/Scripts/LivingEcosystem/UI/EcoUIKit.cs
+++ b/Assets/Scripts/LivingEcosystem/UI/EcoUIKit.cs
@@ -1,0 +1,367 @@
+using System;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace CreateEnv.Ecosystem.UI
+{
+    // Small helpers for building the ecosystem interface entirely from code.
+    //
+    // Building it in code rather than in the scene is deliberate: FreeExploreEndless
+    // is an Addressable scene, and every widget added here would otherwise be a
+    // change to that scene's serialized data. This way the whole feature is additive
+    // and the scene is untouched.
+    public static class EcoUIKit
+    {
+        // Palette. Matches the green the environment builder already uses so the
+        // panel does not look bolted on.
+        public static readonly Color Accent      = new Color32(0x2B, 0xA8, 0x4A, 0xFF);
+        public static readonly Color PanelBg     = new Color32(0x10, 0x1A, 0x24, 0xF2);
+        public static readonly Color PanelBgSoft = new Color32(0x18, 0x26, 0x33, 0xFF);
+        public static readonly Color TextMain    = new Color32(0xF2, 0xF6, 0xFA, 0xFF);
+        public static readonly Color TextDim     = new Color32(0x9F, 0xB2, 0xC4, 0xFF);
+        public static readonly Color Track       = new Color32(0x2C, 0x3C, 0x4C, 0xFF);
+
+        public static Canvas CreateCanvas(string name, int sortOrder)
+        {
+            var go = new GameObject(name, typeof(Canvas), typeof(CanvasScaler), typeof(GraphicRaycaster));
+            var canvas = go.GetComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            // Above the scene's own interface, so the panel is never hidden behind it.
+            canvas.sortingOrder = sortOrder;
+
+            var scaler = go.GetComponent<CanvasScaler>();
+            scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            scaler.referenceResolution = new Vector2(1080f, 1920f);
+            scaler.screenMatchMode = CanvasScaler.ScreenMatchMode.MatchWidthOrHeight;
+            scaler.matchWidthOrHeight = 0.5f;
+            return canvas;
+        }
+
+        public static RectTransform Rect(GameObject go) => go.GetComponent<RectTransform>();
+
+        static Sprite _triangle;
+
+        // An upward triangle, drawn in code. The obvious thing is to print "▲", but
+        // the project's font is LiberationSans, which has no U+25B2 (nor the U+2713
+        // tick) — those come out as missing-glyph boxes. A generated sprite always
+        // draws, whatever font the interface is using.
+        public static Sprite TriangleSprite
+        {
+            get
+            {
+                if (_triangle != null) return _triangle;
+
+                const int size = 32;
+                var tex = new Texture2D(size, size, TextureFormat.RGBA32, false)
+                {
+                    filterMode = FilterMode.Bilinear,
+                    wrapMode = TextureWrapMode.Clamp,
+                    name = "LivingEcosystem/Triangle",
+                };
+
+                var clear = new Color(1f, 1f, 1f, 0f);
+                for (int y = 0; y < size; y++)
+                {
+                    float ny = y / (float)(size - 1);          // 0 at the base
+                    float halfWidth = (1f - ny) * 0.5f;        // widest at the base
+                    for (int x = 0; x < size; x++)
+                    {
+                        float nx = x / (float)(size - 1) - 0.5f;
+                        tex.SetPixel(x, y, Mathf.Abs(nx) <= halfWidth ? Color.white : clear);
+                    }
+                }
+                tex.Apply();
+
+                _triangle = Sprite.Create(tex, new UnityEngine.Rect(0f, 0f, size, size),
+                                          new Vector2(0.5f, 0.5f));
+                return _triangle;
+            }
+        }
+
+        public static GameObject Panel(Transform parent, string name, Color colour)
+        {
+            var go = new GameObject(name, typeof(RectTransform), typeof(Image));
+            go.transform.SetParent(parent, false);
+            var img = go.GetComponent<Image>();
+            img.color = colour;
+            return go;
+        }
+
+        // A section heading with room above it, so a long panel reads as a few
+        // grouped things rather than one continuous list of rows.
+        public static TMP_Text SectionHeader(Transform parent, string title)
+        {
+            var row = Empty(parent, "Section_" + title);
+            var element = row.AddComponent<LayoutElement>();
+            element.preferredHeight = 52f;
+            element.minHeight = 52f;
+
+            var label = Text(row.transform, title.ToUpperInvariant(), 20f, TextDim);
+            label.characterSpacing = 8f;
+            var labelRect = Rect(label.gameObject);
+            labelRect.anchorMin = new Vector2(0f, 0f);
+            labelRect.anchorMax = new Vector2(1f, 0f);
+            labelRect.pivot = new Vector2(0f, 0f);
+            labelRect.sizeDelta = new Vector2(0f, 26f);
+            labelRect.anchoredPosition = new Vector2(2f, 2f);
+
+            // A hairline under the heading, which is what actually separates the
+            // groups; the words alone were getting lost among the rows.
+            var rule = Panel(row.transform, "Rule", new Color(1f, 1f, 1f, 0.10f));
+            var ruleRect = Rect(rule);
+            ruleRect.anchorMin = new Vector2(0f, 0f);
+            ruleRect.anchorMax = new Vector2(1f, 0f);
+            ruleRect.pivot = new Vector2(0.5f, 0f);
+            ruleRect.sizeDelta = new Vector2(0f, 1f);
+            ruleRect.anchoredPosition = new Vector2(0f, 0f);
+
+            return label;
+        }
+
+        public static GameObject Empty(Transform parent, string name)
+        {
+            var go = new GameObject(name, typeof(RectTransform));
+            go.transform.SetParent(parent, false);
+            return go;
+        }
+
+        public static TMP_Text Text(Transform parent, string content, float size,
+                                    Color colour, TextAlignmentOptions align = TextAlignmentOptions.Left)
+        {
+            var go = new GameObject("Text", typeof(RectTransform));
+            go.transform.SetParent(parent, false);
+            var t = go.AddComponent<TextMeshProUGUI>();
+            t.text = content;
+            t.fontSize = size;
+            t.color = colour;
+            t.alignment = align;
+            t.textWrappingMode = TextWrappingModes.Normal;
+            t.raycastTarget = false;
+            return t;
+        }
+
+        public static Button Button(Transform parent, string label, float fontSize,
+                                    Color background, Color textColour, Action onClick)
+        {
+            var go = Panel(parent, "Button", background);
+            var button = go.AddComponent<Button>();
+            button.targetGraphic = go.GetComponent<Image>();
+
+            var text = Text(go.transform, label, fontSize, textColour, TextAlignmentOptions.Center);
+            Stretch(Rect(text.gameObject), 8f, 4f);
+
+            if (onClick != null) button.onClick.AddListener(() => onClick());
+            return button;
+        }
+
+        // A labelled 0..1 slider with a live value readout, matching the row shape the
+        // environment builder already uses.
+        public static Slider LabelledSlider(Transform parent, string label, string initialValue,
+                                            float normalized, Action<float> onChange,
+                                            out TMP_Text valueText)
+        {
+            var row = Empty(parent, "SliderRow");
+            var layout = row.AddComponent<LayoutElement>();
+            layout.preferredHeight = 74f;
+            layout.minHeight = 74f;
+
+            var caption = Text(row.transform, label, 26f, TextDim);
+            var capRect = Rect(caption.gameObject);
+            capRect.anchorMin = new Vector2(0f, 1f);
+            capRect.anchorMax = new Vector2(0.62f, 1f);
+            capRect.pivot = new Vector2(0f, 1f);
+            capRect.anchoredPosition = new Vector2(0f, 0f);
+            capRect.sizeDelta = new Vector2(0f, 30f);
+
+            valueText = Text(row.transform, initialValue, 26f, TextMain, TextAlignmentOptions.Right);
+            var valRect = Rect(valueText.gameObject);
+            valRect.anchorMin = new Vector2(0.62f, 1f);
+            valRect.anchorMax = new Vector2(1f, 1f);
+            valRect.pivot = new Vector2(1f, 1f);
+            valRect.anchoredPosition = Vector2.zero;
+            valRect.sizeDelta = new Vector2(0f, 30f);
+
+            var sliderGo = new GameObject("Slider", typeof(RectTransform));
+            sliderGo.transform.SetParent(row.transform, false);
+            var sRect = Rect(sliderGo);
+            sRect.anchorMin = new Vector2(0f, 0f);
+            sRect.anchorMax = new Vector2(1f, 0f);
+            sRect.pivot = new Vector2(0.5f, 0f);
+            sRect.anchoredPosition = new Vector2(0f, 6f);
+            sRect.sizeDelta = new Vector2(0f, 30f);
+
+            var slider = sliderGo.AddComponent<Slider>();
+
+            var background = Panel(sliderGo.transform, "Track", Track);
+            var bgRect = Rect(background);
+            bgRect.anchorMin = new Vector2(0f, 0.5f);
+            bgRect.anchorMax = new Vector2(1f, 0.5f);
+            bgRect.pivot = new Vector2(0.5f, 0.5f);
+            bgRect.sizeDelta = new Vector2(0f, 8f);
+            bgRect.anchoredPosition = Vector2.zero;
+
+            var fillArea = Empty(sliderGo.transform, "Fill Area");
+            var faRect = Rect(fillArea);
+            faRect.anchorMin = new Vector2(0f, 0.5f);
+            faRect.anchorMax = new Vector2(1f, 0.5f);
+            faRect.pivot = new Vector2(0.5f, 0.5f);
+            faRect.sizeDelta = new Vector2(0f, 8f);
+            faRect.anchoredPosition = Vector2.zero;
+
+            var fill = Panel(fillArea.transform, "Fill", Accent);
+            var fillRect = Rect(fill);
+            fillRect.sizeDelta = new Vector2(0f, 8f);
+
+            var handleArea = Empty(sliderGo.transform, "Handle Slide Area");
+            var haRect = Rect(handleArea);
+            Stretch(haRect, 0f, 0f);
+
+            var handle = Panel(handleArea.transform, "Handle", Color.white);
+            var handleRect = Rect(handle);
+            handleRect.sizeDelta = new Vector2(30f, 30f);
+
+            slider.fillRect = fillRect;
+            slider.handleRect = handleRect;
+            slider.targetGraphic = handle.GetComponent<Image>();
+            slider.direction = Slider.Direction.LeftToRight;
+            slider.minValue = 0f;
+            slider.maxValue = 1f;
+            slider.SetValueWithoutNotify(Mathf.Clamp01(normalized));
+
+            if (onChange != null) slider.onValueChanged.AddListener(v => onChange(v));
+            return slider;
+        }
+
+        // A row of mutually exclusive options — used for Speed and Starting life.
+        public static Button[] SegmentedControl(Transform parent, string label, string[] options,
+                                                int selected, Action<int> onChange)
+        {
+            var row = Empty(parent, "Segmented");
+            var layout = row.AddComponent<LayoutElement>();
+            layout.preferredHeight = 78f;
+            layout.minHeight = 78f;
+
+            var caption = Text(row.transform, label, 26f, TextDim);
+            var capRect = Rect(caption.gameObject);
+            capRect.anchorMin = new Vector2(0f, 1f);
+            capRect.anchorMax = new Vector2(1f, 1f);
+            capRect.pivot = new Vector2(0f, 1f);
+            capRect.sizeDelta = new Vector2(0f, 28f);
+            capRect.anchoredPosition = Vector2.zero;
+
+            var strip = Empty(row.transform, "Options");
+            var stripRect = Rect(strip);
+            stripRect.anchorMin = new Vector2(0f, 0f);
+            stripRect.anchorMax = new Vector2(1f, 0f);
+            stripRect.pivot = new Vector2(0.5f, 0f);
+            stripRect.sizeDelta = new Vector2(0f, 44f);
+            stripRect.anchoredPosition = Vector2.zero;
+
+            var group = strip.AddComponent<HorizontalLayoutGroup>();
+            group.spacing = 6f;
+            group.childForceExpandWidth = true;
+            group.childForceExpandHeight = true;
+            group.childControlWidth = true;
+            group.childControlHeight = true;
+
+            var buttons = new Button[options.Length];
+            for (int i = 0; i < options.Length; i++)
+            {
+                int index = i;
+                buttons[i] = Button(strip.transform, options[i], 24f,
+                                    index == selected ? Accent : Track,
+                                    index == selected ? Color.white : TextDim,
+                                    () => onChange?.Invoke(index));
+            }
+            return buttons;
+        }
+
+        public static void PaintSegments(Button[] buttons, int selected)
+        {
+            if (buttons == null) return;
+            for (int i = 0; i < buttons.Length; i++)
+            {
+                if (buttons[i] == null) continue;
+                var img = buttons[i].GetComponent<Image>();
+                if (img != null) img.color = i == selected ? Accent : Track;
+                var label = buttons[i].GetComponentInChildren<TMP_Text>();
+                if (label != null) label.color = i == selected ? Color.white : TextDim;
+            }
+        }
+
+        public static VerticalLayoutGroup VerticalList(GameObject host, float spacing, RectOffset padding)
+        {
+            var group = host.AddComponent<VerticalLayoutGroup>();
+            group.spacing = spacing;
+            group.padding = padding;
+            group.childForceExpandWidth = true;
+            group.childForceExpandHeight = false;
+            group.childControlWidth = true;
+            group.childControlHeight = true;
+            return group;
+        }
+
+        public static void Stretch(RectTransform rect, float horizontalPadding, float verticalPadding)
+        {
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.pivot = new Vector2(0.5f, 0.5f);
+            rect.offsetMin = new Vector2(horizontalPadding, verticalPadding);
+            rect.offsetMax = new Vector2(-horizontalPadding, -verticalPadding);
+        }
+
+        // A scrollable column, for content that can outgrow the screen.
+        public static RectTransform ScrollColumn(Transform parent, out ScrollRect scrollRect)
+        {
+            var viewport = Panel(parent, "Viewport", new Color(0f, 0f, 0f, 0f));
+
+            // RectMask2D, not Mask. A Mask builds its stencil from the graphic's
+            // alpha, so a fully transparent viewport image clips every child away and
+            // the panel opens empty. RectMask2D clips to the rectangle regardless of
+            // what is drawn, needs no graphic at all, and is cheaper on mobile.
+            viewport.AddComponent<RectMask2D>();
+
+            var content = Empty(viewport.transform, "Content");
+            var contentRect = Rect(content);
+            contentRect.anchorMin = new Vector2(0f, 1f);
+            contentRect.anchorMax = new Vector2(1f, 1f);
+            contentRect.pivot = new Vector2(0.5f, 1f);
+            contentRect.anchoredPosition = Vector2.zero;
+            // A fresh RectTransform defaults to 100x100. With the x anchors stretched,
+            // that leaves the content 100 units WIDER than the viewport, overhanging
+            // 50 units each side and getting clipped at both edges — which is why
+            // "Ecosystem" read as "osystem". Width must come from the anchors alone.
+            contentRect.sizeDelta = new Vector2(0f, 0f);
+
+            // Padding, or the first row butts against the clipping edge and its top
+            // line is shaved off. The bottom margin keeps the last row clear of the
+            // panel edge when the list is scrolled to the end.
+            VerticalList(content, 10f, new RectOffset(4, 4, 8, 20));
+            var fitter = content.AddComponent<ContentSizeFitter>();
+            fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+
+            scrollRect = viewport.AddComponent<ScrollRect>();
+            scrollRect.content = contentRect;
+            scrollRect.viewport = Rect(viewport);
+            scrollRect.horizontal = false;
+            scrollRect.movementType = ScrollRect.MovementType.Clamped;
+            scrollRect.scrollSensitivity = 24f;
+
+            return contentRect;
+        }
+
+        // Ensures there is an EventSystem, so the panel is tappable even if the host
+        // scene somehow lacks one. Never replaces an existing one.
+        public static void EnsureEventSystem()
+        {
+            if (UnityEngine.EventSystems.EventSystem.current != null) return;
+            if (UnityEngine.Object.FindFirstObjectByType<UnityEngine.EventSystems.EventSystem>() != null) return;
+
+            var go = new GameObject("EventSystem (Living Ecosystem)",
+                typeof(UnityEngine.EventSystems.EventSystem),
+                typeof(UnityEngine.EventSystems.StandaloneInputModule));
+            UnityEngine.Object.DontDestroyOnLoad(go);
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/UI/EcoUIKit.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/UI/EcoUIKit.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4c7da57a2cd2b97498607a5996c65903

--- a/Assets/Scripts/LivingEcosystem/UI/EcosystemPanelUI.cs
+++ b/Assets/Scripts/LivingEcosystem/UI/EcosystemPanelUI.cs
@@ -1,0 +1,528 @@
+using System.Collections.Generic;
+using System.Text;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace CreateEnv.Ecosystem.UI
+{
+    // The in-scene ecosystem panel (Design Document 6.1).
+    //
+    // A tab on the edge of the screen slides out a compact panel. It does not pause
+    // the simulation — the point is to watch the ecosystem respond while the panel is
+    // still open. Cause and effect become directly observable rather than remembered.
+    //
+    // Built entirely from code onto its own canvas, so nothing in the host scene is
+    // touched and nothing in it can be disturbed.
+    public class EcosystemPanelUI : MonoBehaviour
+    {
+        LivingReefController _reef;
+
+        RectTransform _panel;
+        RectTransform _tab;
+        bool _open;
+        float _slide;
+
+        TMP_Text _dayText, _healthText, _stageText;
+        Image _healthDot;
+        TMP_Text _temperatureValue, _acidityValue;
+        Slider _temperatureSlider, _aciditySlider;
+        Button[] _speedButtons;
+
+        readonly TMP_Text[] _rowAmount = new TMP_Text[SpeciesLibrary.Count];
+        readonly Image[] _rowTrend = new Image[SpeciesLibrary.Count];
+        readonly TMP_Text[] _rowName = new TMP_Text[SpeciesLibrary.Count];
+        readonly Image[] _rowDots = new Image[SpeciesLibrary.Count];
+        readonly GameObject[] _rowRoot = new GameObject[SpeciesLibrary.Count];
+
+        EnergyPyramidUI _pyramid;
+        OctopusUIHub _octopusUI;
+        TMP_Text _octopusSummary;
+        GameObject _octopusSection;
+        GameObject _octopusHeader;
+        WhyPanelUI _whyPanel;
+        OrganismPickerUI _picker;
+        BarrenPromptUI _barrenPrompt;
+        WelcomeBackUI _welcomeBack;
+        bool _welcomeShown;
+
+        Button _reportButton;
+        EcoToast _toast;
+
+        float _refresh;
+
+        const float PanelWidth = 560f;
+
+        public static EcosystemPanelUI Create(LivingReefController reef)
+        {
+            var canvas = EcoUIKit.CreateCanvas("Living Ecosystem UI", 5000);
+            canvas.transform.SetParent(reef.transform, false);
+            EcoUIKit.EnsureEventSystem();
+
+            var ui = canvas.gameObject.AddComponent<EcosystemPanelUI>();
+            ui._reef = reef;
+            ui.Build(canvas.transform);
+            return ui;
+        }
+
+        void Build(Transform root)
+        {
+            // ── The slide-out panel ──────────────────────────────────────────
+            var panelGo = EcoUIKit.Panel(root, "Panel", EcoUIKit.PanelBg);
+            _panel = EcoUIKit.Rect(panelGo);
+            _panel.anchorMin = new Vector2(1f, 0f);
+            _panel.anchorMax = new Vector2(1f, 1f);
+            _panel.pivot = new Vector2(0f, 0.5f);
+            _panel.sizeDelta = new Vector2(PanelWidth, -180f);
+            _panel.anchoredPosition = new Vector2(0f, 0f);
+
+            // ── The tab that opens it ────────────────────────────────────────
+            var tabButton = EcoUIKit.Button(root, "Reef", 26f, EcoUIKit.Accent, Color.white, Toggle);
+            _tab = EcoUIKit.Rect(tabButton.gameObject);
+            _tab.anchorMin = new Vector2(1f, 0.5f);
+            _tab.anchorMax = new Vector2(1f, 0.5f);
+            _tab.pivot = new Vector2(1f, 0.5f);
+            _tab.sizeDelta = new Vector2(120f, 132f);
+            _tab.anchoredPosition = new Vector2(-8f, 0f);
+
+            var column = EcoUIKit.ScrollColumn(panelGo.transform, out _);
+            var viewport = column.parent as RectTransform;
+            EcoUIKit.Stretch(viewport, 22f, 22f);
+
+            // ── Header ───────────────────────────────────────────────────────
+            var header = EcoUIKit.Empty(column, "Header");
+            header.AddComponent<LayoutElement>().preferredHeight = 64f;
+            var title = EcoUIKit.Text(header.transform, "Ecosystem", 32f, EcoUIKit.TextMain,
+                                      TextAlignmentOptions.Left);
+            EcoUIKit.Stretch(EcoUIKit.Rect(title.gameObject), 0f, 0f);
+
+            var close = EcoUIKit.Button(header.transform, "×", 34f, EcoUIKit.Track, EcoUIKit.TextMain, Toggle);
+            var closeRect = EcoUIKit.Rect(close.gameObject);
+            closeRect.anchorMin = new Vector2(1f, 0.5f);
+            closeRect.anchorMax = new Vector2(1f, 0.5f);
+            closeRect.pivot = new Vector2(1f, 0.5f);
+            closeRect.sizeDelta = new Vector2(52f, 52f);
+            closeRect.anchoredPosition = Vector2.zero;
+
+            // ── Water controls ───────────────────────────────────────────────
+            EcoUIKit.SectionHeader(column, "The water");
+            var s = _reef.Settings;
+            _temperatureSlider = EcoUIKit.LabelledSlider(column, "Temperature",
+                FormatTemperature(s.temperatureC),
+                EcosystemBounds.Temperature.Normalize(s.temperatureC),
+                v =>
+                {
+                    float c = EcosystemBounds.Temperature.Denormalize(v);
+                    _reef.SetTemperature(c);
+                    if (_temperatureValue != null) _temperatureValue.text = FormatTemperature(c);
+                },
+                out _temperatureValue);
+
+            _aciditySlider = EcoUIKit.LabelledSlider(column, "Acidity",
+                FormatAcidity(s.acidityPh),
+                EcosystemBounds.Acidity.Normalize(s.acidityPh),
+                v =>
+                {
+                    float ph = EcosystemBounds.Acidity.Denormalize(v);
+                    _reef.SetAcidity(ph);
+                    if (_acidityValue != null) _acidityValue.text = FormatAcidity(ph);
+                },
+                out _acidityValue);
+
+            _speedButtons = EcoUIKit.SegmentedControl(column, "Speed",
+                EcosystemSettings.SpeedOptions, s.speed, i => { _reef.SetSpeed(i); RefreshSpeed(); });
+
+            // ── Organism readouts ────────────────────────────────────────────
+            EcoUIKit.SectionHeader(column, "Who lives here");
+
+            var organismsHeader = EcoUIKit.Empty(column, "OrganismsHeader");
+            organismsHeader.AddComponent<LayoutElement>().preferredHeight = 46f;
+
+            var addRemove = EcoUIKit.Text(organismsHeader.transform,
+                "Add or remove a species", 21f, EcoUIKit.TextDim);
+            var addRect = EcoUIKit.Rect(addRemove.gameObject);
+            addRect.anchorMin = new Vector2(0f, 0.5f);
+            addRect.anchorMax = new Vector2(0.62f, 0.5f);
+            addRect.pivot = new Vector2(0f, 0.5f);
+            addRect.sizeDelta = new Vector2(0f, 30f);
+            addRect.anchoredPosition = new Vector2(2f, 0f);
+
+            var edit = EcoUIKit.Button(organismsHeader.transform, "Change", 22f,
+                EcoUIKit.Track, EcoUIKit.TextMain, () => _picker.Open());
+            var editRect = EcoUIKit.Rect(edit.gameObject);
+            editRect.anchorMin = new Vector2(1f, 0.5f);
+            editRect.anchorMax = new Vector2(1f, 0.5f);
+            editRect.pivot = new Vector2(1f, 0.5f);
+            editRect.sizeDelta = new Vector2(130f, 44f);
+            editRect.anchoredPosition = new Vector2(-2f, 0f);
+
+            for (int i = 0; i < SpeciesLibrary.Count; i++)
+                BuildOrganismRow(column, i);
+
+            // ── Octopuses ────────────────────────────────────────────────────
+            BuildOctopusSection(column);
+
+            // ── Energy pyramid ───────────────────────────────────────────────
+            EcoUIKit.SectionHeader(column, "Energy");
+            _pyramid = EnergyPyramidUI.Create(column);
+
+            // ── Health and day ───────────────────────────────────────────────
+            EcoUIKit.SectionHeader(column, "How it is doing");
+            var footer = EcoUIKit.Empty(column, "Footer");
+            footer.AddComponent<LayoutElement>().preferredHeight = 118f;
+
+            var dot = EcoUIKit.Panel(footer.transform, "HealthDot", Color.green);
+            _healthDot = dot.GetComponent<Image>();
+            var dotRect = EcoUIKit.Rect(dot);
+            dotRect.anchorMin = new Vector2(0f, 1f);
+            dotRect.anchorMax = new Vector2(0f, 1f);
+            dotRect.pivot = new Vector2(0f, 1f);
+            dotRect.sizeDelta = new Vector2(22f, 22f);
+            dotRect.anchoredPosition = new Vector2(0f, -6f);
+
+            _healthText = EcoUIKit.Text(footer.transform, "Health  balanced", 26f, EcoUIKit.TextMain);
+            var healthRect = EcoUIKit.Rect(_healthText.gameObject);
+            healthRect.anchorMin = new Vector2(0f, 1f);
+            healthRect.anchorMax = new Vector2(1f, 1f);
+            healthRect.pivot = new Vector2(0f, 1f);
+            healthRect.sizeDelta = new Vector2(-34f, 32f);
+            healthRect.anchoredPosition = new Vector2(34f, 0f);
+
+            _stageText = EcoUIKit.Text(footer.transform, "", 22f, EcoUIKit.TextDim);
+            var stageRect = EcoUIKit.Rect(_stageText.gameObject);
+            stageRect.anchorMin = new Vector2(0f, 1f);
+            stageRect.anchorMax = new Vector2(1f, 1f);
+            stageRect.pivot = new Vector2(0f, 1f);
+            stageRect.sizeDelta = new Vector2(-34f, 28f);
+            stageRect.anchoredPosition = new Vector2(34f, -34f);
+
+            _dayText = EcoUIKit.Text(footer.transform, "Day 0", 26f, EcoUIKit.TextMain);
+            var dayRect = EcoUIKit.Rect(_dayText.gameObject);
+            dayRect.anchorMin = new Vector2(0f, 0f);
+            dayRect.anchorMax = new Vector2(0.5f, 0f);
+            dayRect.pivot = new Vector2(0f, 0f);
+            dayRect.sizeDelta = new Vector2(0f, 40f);
+            dayRect.anchoredPosition = Vector2.zero;
+
+            var why = EcoUIKit.Button(footer.transform, "Why?", 24f, EcoUIKit.Accent, Color.white,
+                                      () => _whyPanel.Open());
+            var whyRect = EcoUIKit.Rect(why.gameObject);
+            whyRect.anchorMin = new Vector2(1f, 0f);
+            whyRect.anchorMax = new Vector2(1f, 0f);
+            whyRect.pivot = new Vector2(1f, 0f);
+            whyRect.sizeDelta = new Vector2(150f, 48f);
+            whyRect.anchoredPosition = Vector2.zero;
+
+            BuildReportSection(column);
+
+            // ── Overlays ─────────────────────────────────────────────────────
+            _octopusUI = OctopusUIHub.Create(transform, _reef);
+            _whyPanel = WhyPanelUI.Create(transform, _reef);
+            _picker = OrganismPickerUI.Create(transform, _reef);
+            _barrenPrompt = BarrenPromptUI.Create(transform, _reef);
+
+            _toast = EcoToast.Create(transform);
+
+            _welcomeBack = WelcomeBackUI.Create(transform, _reef);
+            _welcomeBack.onWhyRequested += () => _whyPanel.Open();
+
+            _slide = 1f;   // start closed
+            ApplySlide();
+            Refresh();
+        }
+
+        // Taking the reef away with you (Design Document 7.3).
+        //
+        // Just the button. A paragraph explaining what a "reef report" is tells the
+        // learner something they will find out in one tap, and it sat there for the
+        // whole session to explain a single moment. Where the file went is the one
+        // thing they cannot work out for themselves, and that is what the toast says.
+        void BuildReportSection(Transform column)
+        {
+            EcoUIKit.SectionHeader(column, "Take it with you");
+
+            var host = EcoUIKit.Empty(column, "Report");
+            host.AddComponent<LayoutElement>().preferredHeight = 62f;
+
+            _reportButton = EcoUIKit.Button(host.transform, "Save my reef report", 24f,
+                                            EcoUIKit.Accent, Color.white, SaveReport);
+            var saveRect = EcoUIKit.Rect(_reportButton.gameObject);
+            saveRect.anchorMin = new Vector2(0f, 1f);
+            saveRect.anchorMax = new Vector2(1f, 1f);
+            saveRect.pivot = new Vector2(0.5f, 1f);
+            saveRect.sizeDelta = new Vector2(0f, 56f);
+            saveRect.anchoredPosition = Vector2.zero;
+        }
+
+        void SaveReport()
+        {
+            var label = _reportButton != null
+                ? _reportButton.GetComponentInChildren<TMP_Text>() : null;
+
+            if (_reportButton != null) _reportButton.interactable = false;
+            if (label != null) label.text = "Putting it together…";
+
+            // Two pages of vector drawing: a handful of milliseconds, and doing it
+            // inline means the answer is on screen before the learner's thumb has left
+            // the button. Threading it would cost more in complexity than it saves.
+            var result = Memory.ReportShare.ShareReport(_reef, EnvironmentName());
+
+            if (label != null) label.text = "Save my reef report";
+            if (_reportButton != null) _reportButton.interactable = true;
+
+            _toast.Show(result.message, result.ok ? 5f : 7f);
+        }
+
+        static string EnvironmentName()
+        {
+            var profile = CreateEnv.EnvironmentSession.Selected;
+            return profile != null && !string.IsNullOrEmpty(profile.displayName)
+                ? profile.displayName : "My Reef";
+        }
+
+        // Generation, gene frequencies, and the way into the genetics screens.
+        // The frequency line is the number that visibly moves when the learner warms
+        // the water, so it earns its place on the main panel rather than being buried.
+        void BuildOctopusSection(Transform column)
+        {
+            _octopusHeader = EcoUIKit.SectionHeader(column, "Octopuses").transform.parent.gameObject;
+
+            _octopusSection = EcoUIKit.Empty(column, "Octopuses");
+            _octopusSection.AddComponent<LayoutElement>().preferredHeight = 130f;
+
+            // Three things, evenly spaced, matching the rhythm of the rows above:
+            // an invitation, a way in, and one number worth watching.
+            const float gap = 12f;
+            const float hintHeight = 30f;
+            const float buttonHeight = 46f;
+
+            var hint = EcoUIKit.Text(_octopusSection.transform,
+                                     "Tap an octopus in the water to meet it", 21f, EcoUIKit.TextDim);
+            var hintRect = EcoUIKit.Rect(hint.gameObject);
+            hintRect.anchorMin = new Vector2(0f, 1f);
+            hintRect.anchorMax = new Vector2(1f, 1f);
+            hintRect.pivot = new Vector2(0f, 1f);
+            hintRect.sizeDelta = new Vector2(-4f, hintHeight);
+            hintRect.anchoredPosition = new Vector2(2f, 0f);
+
+            var tree = EcoUIKit.Button(_octopusSection.transform, "Family tree", 22f,
+                                       EcoUIKit.Track, EcoUIKit.TextMain,
+                                       () => _octopusUI.Tree.Open(-1));
+            var treeRect = EcoUIKit.Rect(tree.gameObject);
+            treeRect.anchorMin = new Vector2(0f, 1f);
+            treeRect.anchorMax = new Vector2(1f, 1f);
+            treeRect.pivot = new Vector2(0.5f, 1f);
+            treeRect.sizeDelta = new Vector2(-4f, buttonHeight);
+            treeRect.anchoredPosition = new Vector2(0f, -(hintHeight + gap));
+
+            // The one figure that visibly moves when the learner warms the water, so
+            // it sits on its own under the button rather than inside a block of stats.
+            _octopusSummary = EcoUIKit.Text(_octopusSection.transform, "", 21f, EcoUIKit.TextDim);
+            var sumRect = EcoUIKit.Rect(_octopusSummary.gameObject);
+            sumRect.anchorMin = new Vector2(0f, 1f);
+            sumRect.anchorMax = new Vector2(1f, 1f);
+            sumRect.pivot = new Vector2(0f, 1f);
+            sumRect.sizeDelta = new Vector2(-4f, hintHeight);
+            sumRect.anchoredPosition = new Vector2(2f, -(hintHeight + gap + buttonHeight + gap));
+        }
+
+        void RefreshOctopusSection()
+        {
+            var pop = _reef.Octopuses;
+            if (pop == null || _octopusSummary == null) return;
+
+            bool present = _reef.Sim.IsPresent(SpeciesLibrary.Octopus);
+            // Header and body travel together, or removing the octopus leaves a
+            // heading with nothing underneath it.
+            _octopusSection.SetActive(present);
+            if (_octopusHeader != null) _octopusHeader.SetActive(present);
+            if (!present) return;
+
+            if (pop.AliveCount == 0)
+            {
+                _octopusSummary.text = "None here just now - young drift in from other reefs.";
+                return;
+            }
+
+            int heat = Mathf.RoundToInt(pop.AlleleFrequency(Genetics.GeneId.HeatTolerance) * 100f);
+            _octopusSummary.text = $"Heat-tolerant gene in the family: {heat}%";
+        }
+
+        void BuildOrganismRow(Transform column, int species)
+        {
+            var def = SpeciesLibrary.Get(species);
+            if (def == null) return;
+
+            var row = EcoUIKit.Empty(column, "Row_" + def.id);
+            row.AddComponent<LayoutElement>().preferredHeight = 50f;
+            _rowRoot[species] = row;
+
+            var dot = EcoUIKit.Panel(row.transform, "Dot", def.tint);
+            _rowDots[species] = dot.GetComponent<Image>();
+            var dotRect = EcoUIKit.Rect(dot);
+            dotRect.anchorMin = new Vector2(0f, 0.5f);
+            dotRect.anchorMax = new Vector2(0f, 0.5f);
+            dotRect.pivot = new Vector2(0f, 0.5f);
+            dotRect.sizeDelta = new Vector2(16f, 16f);
+            dotRect.anchoredPosition = new Vector2(2f, 0f);
+
+            _rowName[species] = EcoUIKit.Text(row.transform, def.commonName, 23f, EcoUIKit.TextMain);
+            var nameRect = EcoUIKit.Rect(_rowName[species].gameObject);
+            nameRect.anchorMin = new Vector2(0f, 0f);
+            nameRect.anchorMax = new Vector2(0.68f, 1f);
+            nameRect.pivot = new Vector2(0f, 0.5f);
+            nameRect.offsetMin = new Vector2(28f, 0f);
+            nameRect.offsetMax = Vector2.zero;
+
+            _rowAmount[species] = EcoUIKit.Text(row.transform, "0", 23f, EcoUIKit.TextMain,
+                                                TextAlignmentOptions.Right);
+            var amountRect = EcoUIKit.Rect(_rowAmount[species].gameObject);
+            amountRect.anchorMin = new Vector2(0.68f, 0f);
+            amountRect.anchorMax = new Vector2(0.90f, 1f);
+            amountRect.offsetMin = Vector2.zero;
+            amountRect.offsetMax = Vector2.zero;
+
+            // A generated triangle, rotated for falling. See EcoUIKit.TriangleSprite
+            // for why this is not just an arrow character.
+            var trend = EcoUIKit.Panel(row.transform, "Trend", EcoUIKit.TextDim);
+            var trendImage = trend.GetComponent<Image>();
+            trendImage.sprite = EcoUIKit.TriangleSprite;
+            trendImage.preserveAspect = true;
+            trendImage.raycastTarget = false;
+            _rowTrend[species] = trendImage;
+
+            var trendRect = EcoUIKit.Rect(trend);
+            trendRect.anchorMin = new Vector2(0.94f, 0.5f);
+            trendRect.anchorMax = new Vector2(0.94f, 0.5f);
+            trendRect.pivot = new Vector2(0.5f, 0.5f);
+            trendRect.sizeDelta = new Vector2(18f, 18f);
+            trendRect.anchoredPosition = Vector2.zero;
+
+            // Tapping a row opens that species' card.
+            var button = row.AddComponent<Button>();
+            var hit = row.AddComponent<Image>();
+            hit.color = new Color(0f, 0f, 0f, 0f);
+            button.targetGraphic = hit;
+            int index = species;
+            button.onClick.AddListener(() => _whyPanel.OpenSpecies(index));
+        }
+
+        void Toggle()
+        {
+            _open = !_open;
+        }
+
+        void Update()
+        {
+            // Slide the panel in and out.
+            float target = _open ? 0f : 1f;
+            _slide = Mathf.MoveTowards(_slide, target, Time.unscaledDeltaTime * 4.5f);
+            ApplySlide();
+
+            // Only the tab is on screen when the panel is closed, so there is nothing
+            // to keep up to date. Refreshing anyway meant rebuilding every readout,
+            // the pyramid and the octopus block four times a second, all of it behind
+            // a panel the learner could not see.
+            if (_open || _slide < 0.999f)
+            {
+                _refresh -= Time.unscaledDeltaTime;
+                if (_refresh <= 0f)
+                {
+                    _refresh = 0.25f;
+                    Refresh();
+                }
+            }
+
+            // Shown once, on the first frame the interface is live — which in AR is
+            // after the environment has been placed, so the card is never waiting
+            // behind a plane-scanning screen.
+            if (!_welcomeShown)
+            {
+                _welcomeShown = true;
+                _welcomeBack.ShowIfDue();
+            }
+
+            // The barren prompt appears on its own when the reef bottoms out.
+            if (_reef.Health.stage == CollapseStage.Barren) _barrenPrompt.MaybeShow();
+        }
+
+        void ApplySlide()
+        {
+            float eased = Mathf.SmoothStep(0f, 1f, _slide);
+            _panel.anchoredPosition = new Vector2(-PanelWidth + eased * PanelWidth, 0f);
+            _tab.anchoredPosition = new Vector2(-8f - (1f - eased) * PanelWidth, 0f);
+        }
+
+        void RefreshSpeed()
+        {
+            EcoUIKit.PaintSegments(_speedButtons, _reef.Settings.speed);
+        }
+
+        // Assigning the same string still marks the canvas dirty and costs a full
+        // rebuild, so every readout goes through here.
+        static void Set(TMP_Text field, string value)
+        {
+            if (field != null && field.text != value) field.text = value;
+        }
+
+        void Refresh()
+        {
+            var sim = _reef.Sim;
+            var health = _reef.Health;
+
+            Set(_dayText, "Day " + sim.day);
+
+            var healthColour = EcosystemHealth.Colour(health.level);
+            _healthDot.color = healthColour;
+            Set(_healthText, "Health  " + health.level.ToString().ToLowerInvariant());
+            _healthText.color = healthColour;
+            Set(_stageText, EcosystemHealth.Describe(health.stage));
+
+            var all = SpeciesLibrary.All;
+            for (int i = 0; i < all.Length; i++)
+            {
+                if (_rowRoot[i] == null) continue;
+
+                bool present = sim.IsPresent(i);
+                _rowRoot[i].SetActive(true);
+
+                if (!present)
+                {
+                    _rowName[i].color = EcoUIKit.TextDim;
+                    Set(_rowAmount[i], "removed");
+                    _rowAmount[i].color = EcoUIKit.TextDim;
+                    _rowTrend[i].enabled = false;
+                    _rowDots[i].color = new Color(all[i].tint.r, all[i].tint.g, all[i].tint.b, 0.25f);
+                    continue;
+                }
+
+                _rowName[i].color = EcoUIKit.TextMain;
+                _rowDots[i].color = all[i].tint;
+
+                float amount = sim.DisplayAmount(i);
+                Set(_rowAmount[i], Mathf.RoundToInt(amount).ToString());
+                _rowAmount[i].color = amount > 0f ? EcoUIKit.TextMain : EcoUIKit.TextDim;
+
+                int dir = _reef.Reasons.TrendOf(i);
+                _rowTrend[i].enabled = dir != 0;
+                if (dir != 0)
+                {
+                    _rowTrend[i].color = dir > 0
+                        ? new Color(0.42f, 0.82f, 0.48f)
+                        : new Color(0.90f, 0.46f, 0.42f);
+                    _rowTrend[i].rectTransform.localRotation =
+                        Quaternion.Euler(0f, 0f, dir > 0 ? 0f : 180f);
+                }
+            }
+
+            _pyramid.Refresh(sim);
+            RefreshOctopusSection();
+            RefreshSpeed();
+        }
+
+        public void RefreshOrganismRows() => Refresh();
+
+        static string FormatTemperature(float c) => c.ToString("0.#") + " °C";
+        static string FormatAcidity(float ph) => "pH " + ph.ToString("0.00");
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/UI/EcosystemPanelUI.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/UI/EcosystemPanelUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a31857b298aa4b14984ba0e815e626a9

--- a/Assets/Scripts/LivingEcosystem/UI/EnergyPyramidUI.cs
+++ b/Assets/Scripts/LivingEcosystem/UI/EnergyPyramidUI.cs
@@ -1,0 +1,129 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace CreateEnv.Ecosystem.UI
+{
+    // The live energy pyramid: four tiers whose widths rise and fall with real
+    // biomass (Design Document 1.1). The pyramid narrows because energy is lost at
+    // every step — about a tenth reaches the next level, though it varies a lot
+    // (Literature 2.2). It can go top-heavy, and then inverted, as a reef collapses,
+    // which is the whole point of drawing it live.
+    public class EnergyPyramidUI : MonoBehaviour
+    {
+        struct Tier
+        {
+            public RectTransform bar;
+            public Image fill;
+            public TMP_Text label;
+        }
+
+        readonly Tier[] _tiers = new Tier[4];
+
+        static readonly TrophicLevel[] Levels =
+        {
+            TrophicLevel.TopPredator,
+            TrophicLevel.Hunter,
+            TrophicLevel.PlantEater,
+            TrophicLevel.Producer,
+        };
+
+        static readonly string[] LevelNames =
+        {
+            "Top predator", "Hunter", "Plant eaters", "Producers",
+        };
+
+        static readonly Color[] LevelColours =
+        {
+            new Color(0.42f, 0.52f, 0.62f),
+            new Color(0.80f, 0.42f, 0.62f),
+            new Color(0.90f, 0.58f, 0.32f),
+            new Color(0.44f, 0.76f, 0.42f),
+        };
+
+        public static EnergyPyramidUI Create(Transform column)
+        {
+            var host = EcoUIKit.Empty(column, "EnergyPyramid");
+            host.AddComponent<LayoutElement>().preferredHeight = 210f;
+
+            var ui = host.AddComponent<EnergyPyramidUI>();
+            ui.Build(host.transform);
+            return ui;
+        }
+
+        void Build(Transform host)
+        {
+            var caption = EcoUIKit.Text(host, "About a tenth passes up each step", 20f, EcoUIKit.TextDim);
+            var capRect = EcoUIKit.Rect(caption.gameObject);
+            capRect.anchorMin = new Vector2(0f, 1f);
+            capRect.anchorMax = new Vector2(1f, 1f);
+            capRect.pivot = new Vector2(0f, 1f);
+            capRect.sizeDelta = new Vector2(0f, 28f);
+            capRect.anchoredPosition = Vector2.zero;
+
+            for (int i = 0; i < _tiers.Length; i++)
+            {
+                var rowGo = EcoUIKit.Empty(host, "Tier" + i);
+                var rowRect = EcoUIKit.Rect(rowGo);
+                rowRect.anchorMin = new Vector2(0f, 1f);
+                rowRect.anchorMax = new Vector2(1f, 1f);
+                rowRect.pivot = new Vector2(0.5f, 1f);
+                rowRect.sizeDelta = new Vector2(0f, 40f);
+                rowRect.anchoredPosition = new Vector2(0f, -34f - i * 42f);
+
+                // Bars grow from the centre, so the shape reads as a pyramid.
+                var barGo = EcoUIKit.Panel(rowGo.transform, "Bar", LevelColours[i]);
+                var bar = EcoUIKit.Rect(barGo);
+                bar.anchorMin = new Vector2(0.5f, 0f);
+                bar.anchorMax = new Vector2(0.5f, 1f);
+                bar.pivot = new Vector2(0.5f, 0.5f);
+                bar.sizeDelta = new Vector2(10f, -10f);
+                bar.anchoredPosition = Vector2.zero;
+
+                var label = EcoUIKit.Text(rowGo.transform, LevelNames[i], 20f,
+                                          EcoUIKit.TextMain, TextAlignmentOptions.Center);
+                EcoUIKit.Stretch(EcoUIKit.Rect(label.gameObject), 4f, 0f);
+
+                _tiers[i] = new Tier
+                {
+                    bar = bar,
+                    fill = barGo.GetComponent<Image>(),
+                    label = label,
+                };
+            }
+        }
+
+        public void Refresh(EcosystemSimulation sim)
+        {
+            // Scale every tier against the producers, because that is what the shape
+            // is meant to communicate: how much of the base survives each step up.
+            float producers = Mathf.Max(0.001f, sim.BiomassAtLevel(TrophicLevel.Producer));
+            float widest = ((RectTransform)transform).rect.width - 20f;
+            if (widest <= 0f) widest = 480f;
+
+            for (int i = 0; i < _tiers.Length; i++)
+            {
+                float biomass = sim.BiomassAtLevel(Levels[i]);
+                float share = biomass / producers;
+
+                // A square-root scale so a tier holding a tenth of the base still
+                // reads at a third of the width. A linear scale makes every level
+                // above the producers a hairline and teaches nothing.
+                float width = Mathf.Clamp(Mathf.Sqrt(Mathf.Clamp01(share)) * widest, 8f, widest);
+
+                var size = _tiers[i].bar.sizeDelta;
+                _tiers[i].bar.sizeDelta = new Vector2(Mathf.Lerp(size.x, width, 0.35f), size.y);
+
+                var colour = LevelColours[i];
+                _tiers[i].fill.color = biomass > 0.001f
+                    ? colour
+                    : new Color(colour.r, colour.g, colour.b, 0.18f);
+
+                string label = biomass > 0.001f
+                    ? $"{LevelNames[i]}  {biomass:0.#}"
+                    : LevelNames[i] + "  —";
+                if (_tiers[i].label.text != label) _tiers[i].label.text = label;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/UI/EnergyPyramidUI.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/UI/EnergyPyramidUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ba9d960934d103c48b0a9384733ca67b

--- a/Assets/Scripts/LivingEcosystem/UI/FamilyTreeUI.cs
+++ b/Assets/Scripts/LivingEcosystem/UI/FamilyTreeUI.cs
@@ -1,0 +1,305 @@
+using System.Collections.Generic;
+using System.Text;
+using CreateEnv.Ecosystem.Genetics;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace CreateEnv.Ecosystem.UI
+{
+    // The family tree (Design Document 4.4).
+    //
+    // A column per generation, living animals solid and dead ones faded, the selected
+    // animal highlighted, and a toggle that colours by gene instead of by status so
+    // the learner can literally watch a variant spread down the generations or vanish.
+    //
+    // This is what converts a statistic into a story. A chart showing a gene rising
+    // from 30% to 70% is information; a tree showing that Nova, Tide and their six
+    // descendants all carry their grandmother's camouflage variant while the others
+    // died out is something a learner will remember and retell.
+    public class FamilyTreeUI : MonoBehaviour
+    {
+        LivingReefController _reef;
+        GameObject _root;
+        TMP_Text _title, _body;
+        RectTransform _content;
+        Button[] _colourButtons;
+
+        int _selectedId = -1;
+        int _colourMode;   // 0 = by status, 1..3 = by gene
+
+        public System.Action<int> onAnimalTapped;
+
+        static readonly string[] ColourModes = { "Alive / dead", "Camouflage", "Body size", "Heat tolerance" };
+
+        public static FamilyTreeUI Create(Transform parent, LivingReefController reef)
+        {
+            var host = EcoUIKit.Empty(parent, "FamilyTree");
+            EcoUIKit.Stretch(EcoUIKit.Rect(host), 0f, 0f);
+
+            var ui = host.AddComponent<FamilyTreeUI>();
+            ui._reef = reef;
+            ui.Build(host.transform);
+            return ui;
+        }
+
+        void Build(Transform parent)
+        {
+            var scrim = EcoUIKit.Panel(parent, "Scrim", new Color(0f, 0f, 0f, 0.68f));
+            EcoUIKit.Stretch(EcoUIKit.Rect(scrim), 0f, 0f);
+
+            var card = EcoUIKit.Panel(scrim.transform, "Card", EcoUIKit.PanelBgSoft);
+            var cardRect = EcoUIKit.Rect(card);
+            cardRect.anchorMin = new Vector2(0.5f, 0.5f);
+            cardRect.anchorMax = new Vector2(0.5f, 0.5f);
+            cardRect.pivot = new Vector2(0.5f, 0.5f);
+            cardRect.sizeDelta = new Vector2(940f, 1360f);
+
+            _title = EcoUIKit.Text(card.transform, "Family tree", 34f, EcoUIKit.TextMain);
+            var titleRect = EcoUIKit.Rect(_title.gameObject);
+            titleRect.anchorMin = new Vector2(0f, 1f);
+            titleRect.anchorMax = new Vector2(1f, 1f);
+            titleRect.pivot = new Vector2(0.5f, 1f);
+            titleRect.sizeDelta = new Vector2(-60f, 48f);
+            titleRect.anchoredPosition = new Vector2(0f, -24f);
+
+            // Colour-by toggle.
+            var strip = EcoUIKit.Empty(card.transform, "ColourBy");
+            var stripRect = EcoUIKit.Rect(strip);
+            stripRect.anchorMin = new Vector2(0f, 1f);
+            stripRect.anchorMax = new Vector2(1f, 1f);
+            stripRect.pivot = new Vector2(0.5f, 1f);
+            stripRect.sizeDelta = new Vector2(-56f, 46f);
+            stripRect.anchoredPosition = new Vector2(0f, -80f);
+
+            var group = strip.AddComponent<HorizontalLayoutGroup>();
+            group.spacing = 6f;
+            group.childForceExpandWidth = true;
+            group.childForceExpandHeight = true;
+            group.childControlWidth = true;
+            group.childControlHeight = true;
+
+            _colourButtons = new Button[ColourModes.Length];
+            for (int i = 0; i < ColourModes.Length; i++)
+            {
+                int mode = i;
+                _colourButtons[i] = EcoUIKit.Button(strip.transform, ColourModes[i], 20f,
+                                                    EcoUIKit.Track, EcoUIKit.TextDim,
+                                                    () => { _colourMode = mode; Refresh(); });
+            }
+
+            var scrollHost = EcoUIKit.Empty(card.transform, "Scroll");
+            var scrollRect = EcoUIKit.Rect(scrollHost);
+            scrollRect.anchorMin = Vector2.zero;
+            scrollRect.anchorMax = Vector2.one;
+            scrollRect.offsetMin = new Vector2(38f, 112f);
+            scrollRect.offsetMax = new Vector2(-38f, -142f);
+
+            _content = EcoUIKit.ScrollColumn(scrollHost.transform, out _);
+            EcoUIKit.Stretch(EcoUIKit.Rect(_content.parent.gameObject), 0f, 0f);
+
+            _body = EcoUIKit.Text(_content, "", 22f, EcoUIKit.TextMain);
+            _body.gameObject.AddComponent<LayoutElement>().minHeight = 60f;
+            var fitter = _body.gameObject.AddComponent<ContentSizeFitter>();
+            fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+
+            var close = EcoUIKit.Button(card.transform, "Close", 24f, EcoUIKit.Track,
+                                        EcoUIKit.TextMain, Close);
+            var closeRect = EcoUIKit.Rect(close.gameObject);
+            closeRect.anchorMin = new Vector2(0.5f, 0f);
+            closeRect.anchorMax = new Vector2(0.5f, 0f);
+            closeRect.pivot = new Vector2(0.5f, 0f);
+            closeRect.sizeDelta = new Vector2(320f, 56f);
+            closeRect.anchoredPosition = new Vector2(0f, 26f);
+
+            _root = scrim;
+            _root.SetActive(false);
+        }
+
+        public void Close() => _root.SetActive(false);
+
+        public void Open(int selectedId)
+        {
+            _selectedId = selectedId;
+            Refresh();
+            _root.SetActive(true);
+        }
+
+        struct Entry
+        {
+            public int id;
+            public string name;
+            public Genome genome;
+            public int generation;
+            public bool alive;
+            public Sex sex;
+            public CauseOfDeath cause;
+            public int motherId, fatherId;
+        }
+
+        void Refresh()
+        {
+            for (int i = 0; i < _colourButtons.Length; i++)
+            {
+                var img = _colourButtons[i].GetComponent<Image>();
+                if (img != null) img.color = i == _colourMode ? EcoUIKit.Accent : EcoUIKit.Track;
+                var label = _colourButtons[i].GetComponentInChildren<TMP_Text>();
+                if (label != null) label.color = i == _colourMode ? Color.white : EcoUIKit.TextDim;
+            }
+
+            var pop = _reef.Octopuses;
+            if (pop == null) { _body.text = "No octopuses on this reef."; return; }
+
+            // Gather the living and the remembered dead into one list.
+            var entries = new List<Entry>(pop.agents.Count + pop.ancestors.Count);
+            foreach (var a in pop.agents)
+            {
+                if (!a.IsAlive) continue;
+                entries.Add(new Entry
+                {
+                    id = a.id, name = a.name, genome = a.genome, generation = a.generation,
+                    alive = true, sex = a.sex, cause = CauseOfDeath.StillAlive,
+                    motherId = a.motherId, fatherId = a.fatherId,
+                });
+            }
+            foreach (var r in pop.ancestors)
+            {
+                entries.Add(new Entry
+                {
+                    id = r.id, name = r.Name, genome = r.genome, generation = r.generation,
+                    alive = false, sex = r.Sex, cause = r.Cause,
+                    motherId = r.motherId, fatherId = r.fatherId,
+                });
+            }
+
+            if (entries.Count == 0) { _body.text = "No octopuses yet."; return; }
+
+            int newest = pop.HighestGeneration;
+            int oldestShown = Mathf.Max(1, newest - OctopusPopulation.GenerationCap + 1);
+
+            var sb = new StringBuilder();
+            sb.Append("<color=#9FB2C4>")
+              .Append(pop.AliveCount).Append(" alive · ")
+              .Append(pop.TotalBorn).Append(" born · ")
+              .Append(pop.TotalDied).Append(" died · generation ").Append(newest)
+              .Append("</color>\n\n");
+
+            // Anything older than the cap is one summary row, so a long session's tree
+            // stays readable instead of scrolling for ever.
+            int olderCount = 0;
+            foreach (var e in entries) if (e.generation < oldestShown) olderCount++;
+            if (olderCount > 0)
+            {
+                sb.Append("<color=#66788C>Generations 1 to ").Append(oldestShown - 1)
+                  .Append(" — ").Append(olderCount).Append(" earlier octopuses, no longer shown")
+                  .Append("</color>\n\n");
+            }
+
+            for (int gen = oldestShown; gen <= newest; gen++)
+            {
+                var inGeneration = new List<Entry>();
+                foreach (var e in entries) if (e.generation == gen) inGeneration.Add(e);
+                if (inGeneration.Count == 0) continue;
+
+                sb.Append("<b>Generation ").Append(gen).Append("</b>\n");
+
+                foreach (var e in inGeneration)
+                {
+                    string colour = ColourFor(e);
+                    string marker = e.alive ? "●" : "○";
+                    bool selected = e.id == _selectedId;
+
+                    sb.Append("  <color=").Append(colour).Append('>').Append(marker).Append(' ');
+                    if (selected) sb.Append("<b>");
+                    sb.Append(e.name);
+                    if (selected) sb.Append("</b>");
+                    sb.Append("</color>");
+
+                    sb.Append("  <color=#9FB2C4>").Append(e.genome.Notation());
+                    sb.Append(e.sex == Sex.Female ? "  F" : "  M");
+
+                    if (e.motherId >= 0 || e.fatherId >= 0)
+                        sb.Append("  ← ").Append(pop.NameOf(e.motherId))
+                          .Append(" + ").Append(pop.NameOf(e.fatherId));
+                    else if (gen > 1)
+                        sb.Append("  ← settled from the plankton");
+
+                    if (!e.alive) sb.Append("  · ").Append(OctopusAgent.CauseWord(e.cause));
+                    sb.Append("</color>\n");
+                }
+                sb.Append('\n');
+            }
+
+            sb.Append(Legend());
+            _body.text = sb.ToString();
+
+            BuildTapTargets(entries, oldestShown, newest);
+        }
+
+        string ColourFor(Entry e)
+        {
+            if (_colourMode == 0)
+                return e.alive ? "#F2F6FA" : "#66788C";
+
+            var gene = (GeneId)(_colourMode - 1);
+            int copies = e.genome.CopiesOf(gene);
+
+            // Two copies, one copy, none — three steps, so a variant spreading down
+            // the generations is visible as the column changing colour.
+            string full = copies switch { 2 => "#2BA84A", 1 => "#C9A227", _ => "#9A4B3F" };
+            return e.alive ? full : Fade(full);
+        }
+
+        // Dead animals are shown in the same hue, dimmed, so a lineage reads as one
+        // thread whether or not its members are still alive.
+        static string Fade(string hex) => hex switch
+        {
+            "#2BA84A" => "#1C6B31",
+            "#C9A227" => "#816819",
+            _         => "#63302A",
+        };
+
+        string Legend()
+        {
+            if (_colourMode == 0)
+                return "<color=#9FB2C4>● alive   ○ dead</color>";
+
+            var gene = (GeneId)(_colourMode - 1);
+            char upper = Genome.LetterOf(gene);
+            char lower = char.ToLowerInvariant(upper);
+            return $"<color=#2BA84A>■ {upper}{upper}</color>   " +
+                   $"<color=#C9A227>■ {upper}{lower}</color>   " +
+                   $"<color=#9A4B3F>■ {lower}{lower}</color>   " +
+                   $"<color=#9FB2C4>(faded = dead)</color>\n" +
+                   $"<color=#9FB2C4>{Genome.DescriptionOf(gene)}</color>";
+        }
+
+        readonly List<GameObject> _taps = new List<GameObject>(32);
+
+        // A row of buttons under the tree, so any animal in it — living or dead — can
+        // be opened in the inspector.
+        void BuildTapTargets(List<Entry> entries, int oldestShown, int newest)
+        {
+            for (int i = 0; i < _taps.Count; i++) if (_taps[i] != null) Destroy(_taps[i]);
+            _taps.Clear();
+
+            var header = EcoUIKit.Text(_content, "\nTap any octopus to inspect it", 22f, EcoUIKit.TextDim);
+            header.gameObject.AddComponent<LayoutElement>().preferredHeight = 44f;
+            _taps.Add(header.gameObject);
+
+            foreach (var e in entries)
+            {
+                if (e.generation < oldestShown) continue;
+                int id = e.id;
+                string label = $"{e.name}   {e.genome.Notation()}   gen {e.generation}" +
+                               (e.alive ? "" : "   (dead)");
+                var button = EcoUIKit.Button(_content, label, 21f,
+                                             e.alive ? EcoUIKit.Track : new Color32(0x1A, 0x24, 0x2E, 0xFF),
+                                             e.alive ? EcoUIKit.TextMain : EcoUIKit.TextDim,
+                                             () => onAnimalTapped?.Invoke(id));
+                button.gameObject.AddComponent<LayoutElement>().preferredHeight = 50f;
+                _taps.Add(button.gameObject);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/UI/FamilyTreeUI.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/UI/FamilyTreeUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 75fc2110617bc7b4d8cf7e3fc995fa09

--- a/Assets/Scripts/LivingEcosystem/UI/OctopusInspectorUI.cs
+++ b/Assets/Scripts/LivingEcosystem/UI/OctopusInspectorUI.cs
@@ -1,0 +1,251 @@
+using System.Text;
+using CreateEnv.Ecosystem.Genetics;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace CreateEnv.Ecosystem.UI
+{
+    // Tap an octopus to see its genes, its traits against the population average, its
+    // age, its generation and its parents (Milestone Step 2, Inspector).
+    //
+    // The card is deliberately explicit about the difference between genotype and
+    // phenotype, because that distinction is the whole lesson: it prints the pair of
+    // variants the animal carries AND what those variants produced, side by side.
+    public class OctopusInspectorUI : MonoBehaviour
+    {
+        LivingReefController _reef;
+        GameObject _root;
+        TMP_Text _title, _subtitle, _body;
+        RectTransform _content;
+        Button _breedButton, _treeButton;
+
+        int _shownId = -1;
+
+        public System.Action<int> onBreedRequested;
+        public System.Action<int> onTreeRequested;
+
+        public int ShownId => _shownId;
+        public bool IsOpen => _root != null && _root.activeSelf;
+
+        public static OctopusInspectorUI Create(Transform parent, LivingReefController reef)
+        {
+            var host = EcoUIKit.Empty(parent, "OctopusInspector");
+            EcoUIKit.Stretch(EcoUIKit.Rect(host), 0f, 0f);
+
+            var ui = host.AddComponent<OctopusInspectorUI>();
+            ui._reef = reef;
+            ui.Build(host.transform);
+            return ui;
+        }
+
+        void Build(Transform parent)
+        {
+            var scrim = EcoUIKit.Panel(parent, "Scrim", new Color(0f, 0f, 0f, 0.62f));
+            EcoUIKit.Stretch(EcoUIKit.Rect(scrim), 0f, 0f);
+            var scrimButton = scrim.AddComponent<Button>();
+            scrimButton.targetGraphic = scrim.GetComponent<Image>();
+            scrimButton.onClick.AddListener(Close);
+
+            var card = EcoUIKit.Panel(scrim.transform, "Card", EcoUIKit.PanelBgSoft);
+            var cardRect = EcoUIKit.Rect(card);
+            cardRect.anchorMin = new Vector2(0.5f, 0.5f);
+            cardRect.anchorMax = new Vector2(0.5f, 0.5f);
+            cardRect.pivot = new Vector2(0.5f, 0.5f);
+            cardRect.sizeDelta = new Vector2(900f, 1280f);
+
+            _title = EcoUIKit.Text(card.transform, "", 38f, EcoUIKit.TextMain);
+            var titleRect = EcoUIKit.Rect(_title.gameObject);
+            titleRect.anchorMin = new Vector2(0f, 1f);
+            titleRect.anchorMax = new Vector2(1f, 1f);
+            titleRect.pivot = new Vector2(0.5f, 1f);
+            titleRect.sizeDelta = new Vector2(-64f, 50f);
+            titleRect.anchoredPosition = new Vector2(0f, -24f);
+
+            _subtitle = EcoUIKit.Text(card.transform, "", 24f, EcoUIKit.TextDim);
+            var subRect = EcoUIKit.Rect(_subtitle.gameObject);
+            subRect.anchorMin = new Vector2(0f, 1f);
+            subRect.anchorMax = new Vector2(1f, 1f);
+            subRect.pivot = new Vector2(0.5f, 1f);
+            subRect.sizeDelta = new Vector2(-64f, 34f);
+            subRect.anchoredPosition = new Vector2(0f, -74f);
+
+            var scrollHost = EcoUIKit.Empty(card.transform, "Scroll");
+            var scrollRect = EcoUIKit.Rect(scrollHost);
+            scrollRect.anchorMin = Vector2.zero;
+            scrollRect.anchorMax = Vector2.one;
+            scrollRect.offsetMin = new Vector2(40f, 190f);
+            scrollRect.offsetMax = new Vector2(-40f, -124f);
+
+            _content = EcoUIKit.ScrollColumn(scrollHost.transform, out _);
+            EcoUIKit.Stretch(EcoUIKit.Rect(_content.parent.gameObject), 0f, 0f);
+
+            _body = EcoUIKit.Text(_content, "", 24f, EcoUIKit.TextMain);
+            _body.gameObject.AddComponent<LayoutElement>().minHeight = 60f;
+            var fitter = _body.gameObject.AddComponent<ContentSizeFitter>();
+            fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+
+            _breedButton = EcoUIKit.Button(card.transform, "Breed this octopus", 24f,
+                                           EcoUIKit.Accent, Color.white,
+                                           () => onBreedRequested?.Invoke(_shownId));
+            var breedRect = EcoUIKit.Rect(_breedButton.gameObject);
+            breedRect.anchorMin = new Vector2(0f, 0f);
+            breedRect.anchorMax = new Vector2(0.5f, 0f);
+            breedRect.pivot = new Vector2(0f, 0f);
+            breedRect.sizeDelta = new Vector2(-38f, 58f);
+            breedRect.anchoredPosition = new Vector2(30f, 96f);
+
+            _treeButton = EcoUIKit.Button(card.transform, "Family tree", 24f,
+                                          EcoUIKit.Track, EcoUIKit.TextMain,
+                                          () => onTreeRequested?.Invoke(_shownId));
+            var treeRect = EcoUIKit.Rect(_treeButton.gameObject);
+            treeRect.anchorMin = new Vector2(0.5f, 0f);
+            treeRect.anchorMax = new Vector2(1f, 0f);
+            treeRect.pivot = new Vector2(1f, 0f);
+            treeRect.sizeDelta = new Vector2(-38f, 58f);
+            treeRect.anchoredPosition = new Vector2(-30f, 96f);
+
+            var close = EcoUIKit.Button(card.transform, "Close", 24f, EcoUIKit.Track,
+                                        EcoUIKit.TextMain, Close);
+            var closeRect = EcoUIKit.Rect(close.gameObject);
+            closeRect.anchorMin = new Vector2(0.5f, 0f);
+            closeRect.anchorMax = new Vector2(0.5f, 0f);
+            closeRect.pivot = new Vector2(0.5f, 0f);
+            closeRect.sizeDelta = new Vector2(320f, 56f);
+            closeRect.anchoredPosition = new Vector2(0f, 26f);
+
+            _root = scrim;
+            _root.SetActive(false);
+        }
+
+        public void Close() => _root.SetActive(false);
+
+        public void Open(int agentId)
+        {
+            var pop = _reef.Octopuses;
+            if (pop == null) return;
+
+            _shownId = agentId;
+            var agent = pop.ById(agentId);
+
+            if (agent != null) ShowLiving(agent, pop);
+            else if (pop.TryAncestor(agentId, out var record)) ShowAncestor(record, pop);
+            else return;
+
+            _root.SetActive(true);
+        }
+
+        void ShowLiving(OctopusAgent a, OctopusPopulation pop)
+        {
+            _title.text = a.name;
+            _subtitle.text = $"Octopus vulgaris · {a.SexWord} · generation {a.generation}";
+
+            _breedButton.gameObject.SetActive(true);
+            bool canBreed = a.IsMature(OctopusPopulation.MaturityDays) && !a.IsBrooding;
+            _breedButton.interactable = canBreed;
+            var label = _breedButton.GetComponentInChildren<TMP_Text>();
+            if (label != null)
+                label.text = a.IsBrooding ? "Already brooding"
+                           : canBreed ? "Breed this octopus"
+                           : "Not mature yet";
+
+            var sb = new StringBuilder();
+
+            sb.Append("<b>Right now</b>\n").Append(a.StateWord).Append('\n');
+            sb.Append("Age ").Append(Mathf.RoundToInt(a.ageDays)).Append(" days");
+            if (a.IsMature(OctopusPopulation.MaturityDays)) sb.Append(" · mature");
+            else sb.Append(" · matures at ").Append(Mathf.RoundToInt(OctopusPopulation.MaturityDays));
+            sb.Append('\n');
+            sb.Append("Condition ").Append(ConditionWord(a.energy)).Append("\n\n");
+
+            // ── The genome, gene by gene ─────────────────────────────────────
+            sb.Append("<b>Its genes</b>   <size=130%><b>").Append(a.genome.Notation())
+              .Append("</b></size>\n");
+            sb.Append("<color=#9FB2C4>Two copies of each gene, one from each parent.</color>\n\n");
+
+            foreach (GeneId gene in System.Enum.GetValues(typeof(GeneId)))
+            {
+                sb.Append("<b>").Append(Genome.NameOf(gene)).Append("</b>  ")
+                  .Append(a.genome.Notation(gene)).Append("  —  ")
+                  .Append(a.traits.WordFor(gene)).Append('\n');
+                sb.Append(Bar(a.traits.ValueOf(gene))).Append("  it\n");
+                sb.Append(Bar(pop.AverageTrait(gene))).Append("  <color=#9FB2C4>the others</color>\n");
+
+                if (a.genome.IsHeterozygous(gene) && gene == GeneId.Camouflage)
+                    sb.Append("<color=#9FB2C4>Carries a hidden weak copy — it can reappear " +
+                              "in its young.</color>\n");
+
+                sb.Append('\n');
+            }
+
+            // ── Where it came from ───────────────────────────────────────────
+            sb.Append("<b>Parents</b>\n");
+            if (a.motherId < 0 && a.fatherId < 0)
+                sb.Append(a.generation <= 1
+                    ? "None here — it was among the first octopuses on this reef.\n\n"
+                    : "None here — it settled from the plankton, spawned on another reef.\n\n");
+            else
+                sb.Append("Mother: ").Append(pop.NameOf(a.motherId))
+                  .Append("\nFather: ").Append(pop.NameOf(a.fatherId)).Append("\n\n");
+
+            sb.Append("<color=#9FB2C4>Real octopuses have thousands of genes; three are shown here " +
+                      "for clarity. Mutation and growing up are both sped up so you can watch " +
+                      "several generations in one sitting.</color>");
+
+            _body.text = sb.ToString();
+        }
+
+        void ShowAncestor(AncestorRecord r, OctopusPopulation pop)
+        {
+            _title.text = r.Name;
+            _subtitle.text = $"Octopus vulgaris · {r.Sex} · generation {r.generation} · died";
+            _breedButton.gameObject.SetActive(false);
+
+            var sb = new StringBuilder();
+            sb.Append("<b>This octopus is dead</b>\n");
+            sb.Append("It ").Append(OctopusAgent.CauseWord(r.Cause))
+              .Append(" at ").Append(r.ageAtDeath).Append(" days old, on day ")
+              .Append(r.diedOnDay).Append(".\n\n");
+
+            sb.Append("<b>Its genes</b>\n");
+            sb.Append("<size=130%><b>").Append(r.genome.Notation()).Append("</b></size>\n\n");
+            foreach (GeneId gene in System.Enum.GetValues(typeof(GeneId)))
+            {
+                sb.Append("<b>").Append(Genome.NameOf(gene)).Append("</b>   ")
+                  .Append(r.genome.Notation(gene)).Append("  ")
+                  .Append(PunnettPrediction.PhenotypeWord(gene, r.genome.CopiesOf(gene)))
+                  .Append('\n');
+            }
+            sb.Append('\n');
+
+            sb.Append("<b>Parents</b>\n");
+            if (r.motherId < 0 && r.fatherId < 0)
+                sb.Append("None here — a founder or a settler.\n\n");
+            else
+                sb.Append("Mother: ").Append(pop.NameOf(r.motherId))
+                  .Append("\nFather: ").Append(pop.NameOf(r.fatherId)).Append("\n\n");
+
+            sb.Append("<color=#9FB2C4>Its genes are kept after death so the family tree still " +
+                      "shows where its descendants came from.</color>");
+
+            _body.text = sb.ToString();
+        }
+
+        static string ConditionWord(float energy) =>
+            energy > 1.5f ? "well fed" : energy > 0.9f ? "feeding normally"
+            : energy > 0.4f ? "thin" : "close to starving";
+
+        // A plain text bar, so trait strength reads at a glance without a chart.
+        static string Bar(float value01)
+        {
+            const int width = 12;
+            int filled = Mathf.Clamp(Mathf.RoundToInt(Mathf.Clamp01(value01) * width), 0, width);
+            var sb = new StringBuilder("<color=#2BA84A>");
+            for (int i = 0; i < filled; i++) sb.Append('=');
+            sb.Append("</color><color=#2C3C4C>");
+            for (int i = filled; i < width; i++) sb.Append('=');
+            sb.Append("</color>");
+            return sb.ToString();
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/UI/OctopusInspectorUI.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/UI/OctopusInspectorUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9b4112ce622d1cd489b800b95f77bbe6

--- a/Assets/Scripts/LivingEcosystem/UI/OctopusUIHub.cs
+++ b/Assets/Scripts/LivingEcosystem/UI/OctopusUIHub.cs
@@ -1,0 +1,99 @@
+using CreateEnv.Ecosystem.Genetics;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace CreateEnv.Ecosystem.UI
+{
+    // Ties the three genetics screens together and turns a tap on an octopus in the
+    // world into an inspector card.
+    //
+    // Tapping in AR is fiddly — the animals are small, they move, and a phone is held
+    // one-handed — so there are two ways in: tap the octopus itself, or pick it from
+    // the list in the ecosystem panel. Learners who cannot land the tap are exactly
+    // the ones who most need the card.
+    public class OctopusUIHub : MonoBehaviour
+    {
+        LivingReefController _reef;
+
+        public OctopusInspectorUI Inspector { get; private set; }
+        public BreedingToolUI Breeding { get; private set; }
+        public FamilyTreeUI Tree { get; private set; }
+
+        static readonly RaycastHit[] _hits = new RaycastHit[8];
+
+        public static OctopusUIHub Create(Transform canvas, LivingReefController reef)
+        {
+            var host = EcoUIKit.Empty(canvas, "OctopusUI");
+            EcoUIKit.Stretch(EcoUIKit.Rect(host), 0f, 0f);
+
+            var hub = host.AddComponent<OctopusUIHub>();
+            hub._reef = reef;
+
+            hub.Inspector = OctopusInspectorUI.Create(host.transform, reef);
+            hub.Breeding = BreedingToolUI.Create(host.transform, reef);
+            hub.Tree = FamilyTreeUI.Create(host.transform, reef);
+
+            hub.Inspector.onBreedRequested += id =>
+            {
+                hub.Inspector.Close();
+                hub.Breeding.Open(id);
+            };
+            hub.Inspector.onTreeRequested += id =>
+            {
+                hub.Inspector.Close();
+                hub.Tree.Open(id);
+            };
+            hub.Tree.onAnimalTapped += id =>
+            {
+                hub.Tree.Close();
+                hub.Inspector.Open(id);
+            };
+
+            return hub;
+        }
+
+        public void Inspect(int agentId) => Inspector.Open(agentId);
+
+        void Update()
+        {
+            if (_reef == null || _reef.Octopuses == null) return;
+            if (Inspector.IsOpen) return;
+
+            if (!TryGetTap(out Vector2 screenPoint)) return;
+
+            // A tap that landed on the interface is not a tap on the reef.
+            if (EventSystem.current != null && EventSystem.current.IsPointerOverGameObject()) return;
+
+            var cam = Camera.main;
+            if (cam == null) return;
+
+            var ray = cam.ScreenPointToRay(screenPoint);
+            int count = Physics.RaycastNonAlloc(ray, _hits, 60f);
+            for (int i = 0; i < count; i++)
+            {
+                var view = _hits[i].collider != null
+                    ? _hits[i].collider.GetComponentInParent<OctopusAgentView>()
+                    : null;
+                if (view == null || view.agentId < 0) continue;
+
+                Inspector.Open(view.agentId);
+                return;
+            }
+        }
+
+        static bool TryGetTap(out Vector2 point)
+        {
+            point = default;
+#if UNITY_EDITOR || UNITY_STANDALONE
+            if (Input.GetMouseButtonDown(0)) { point = Input.mousePosition; return true; }
+            return false;
+#else
+            if (Input.touchCount == 0) return false;
+            var touch = Input.GetTouch(0);
+            if (touch.phase != TouchPhase.Began) return false;
+            point = touch.position;
+            return true;
+#endif
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/UI/OctopusUIHub.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/UI/OctopusUIHub.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 68be5a9e00214e24b8d08389f700ba0b

--- a/Assets/Scripts/LivingEcosystem/UI/OrganismPickerUI.cs
+++ b/Assets/Scripts/LivingEcosystem/UI/OrganismPickerUI.cs
@@ -1,0 +1,213 @@
+using System.Collections.Generic;
+using System.Text;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace CreateEnv.Ecosystem.UI
+{
+    // The organism picker (Design Document 5.1). Nine species as checkboxes, all on
+    // by default, grouped by their level in the pyramid.
+    //
+    // Unchecking a species removes it entirely and the web reorganises around the
+    // gap. The learner is always allowed to build an unbalanced ecosystem — breaking
+    // it is the lesson — so the warnings under the list guide without blocking.
+    public class OrganismPickerUI : MonoBehaviour
+    {
+        LivingReefController _reef;
+        GameObject _root;
+        TMP_Text _warnings;
+
+        readonly Image[] _checkBoxes = new Image[SpeciesLibrary.Count];
+        readonly GameObject[] _checkMarks = new GameObject[SpeciesLibrary.Count];
+        readonly bool[] _draft = new bool[SpeciesLibrary.Count];
+
+        public static OrganismPickerUI Create(Transform parent, LivingReefController reef)
+        {
+            var host = EcoUIKit.Empty(parent, "OrganismPicker");
+            EcoUIKit.Stretch(EcoUIKit.Rect(host), 0f, 0f);
+
+            var ui = host.AddComponent<OrganismPickerUI>();
+            ui._reef = reef;
+            ui.Build(host.transform);
+            return ui;
+        }
+
+        void Build(Transform parent)
+        {
+            var scrim = EcoUIKit.Panel(parent, "Scrim", new Color(0f, 0f, 0f, 0.62f));
+            EcoUIKit.Stretch(EcoUIKit.Rect(scrim), 0f, 0f);
+
+            var card = EcoUIKit.Panel(scrim.transform, "Card", EcoUIKit.PanelBgSoft);
+            var cardRect = EcoUIKit.Rect(card);
+            cardRect.anchorMin = new Vector2(0.5f, 0.5f);
+            cardRect.anchorMax = new Vector2(0.5f, 0.5f);
+            cardRect.pivot = new Vector2(0.5f, 0.5f);
+            cardRect.sizeDelta = new Vector2(900f, 1240f);
+
+            var title = EcoUIKit.Text(card.transform, "Which organisms are present?", 32f, EcoUIKit.TextMain);
+            var titleRect = EcoUIKit.Rect(title.gameObject);
+            titleRect.anchorMin = new Vector2(0f, 1f);
+            titleRect.anchorMax = new Vector2(1f, 1f);
+            titleRect.pivot = new Vector2(0.5f, 1f);
+            titleRect.sizeDelta = new Vector2(-64f, 52f);
+            titleRect.anchoredPosition = new Vector2(0f, -26f);
+
+            var scrollHost = EcoUIKit.Empty(card.transform, "Scroll");
+            var scrollRect = EcoUIKit.Rect(scrollHost);
+            scrollRect.anchorMin = Vector2.zero;
+            scrollRect.anchorMax = Vector2.one;
+            scrollRect.offsetMin = new Vector2(40f, 262f);
+            scrollRect.offsetMax = new Vector2(-40f, -100f);
+
+            var column = EcoUIKit.ScrollColumn(scrollHost.transform, out _);
+            EcoUIKit.Stretch(EcoUIKit.Rect(column.parent.gameObject), 0f, 0f);
+
+            BuildGroup(column, "Producers", TrophicLevel.Producer);
+            BuildGroup(column, "Plant eaters", TrophicLevel.PlantEater);
+            BuildGroup(column, "Hunters", TrophicLevel.Hunter, TrophicLevel.TopPredator);
+
+            // Warnings sit under the list, where the choices are made.
+            _warnings = EcoUIKit.Text(card.transform, "", 22f, new Color(0.96f, 0.76f, 0.36f));
+            var warnRect = EcoUIKit.Rect(_warnings.gameObject);
+            warnRect.anchorMin = new Vector2(0f, 0f);
+            warnRect.anchorMax = new Vector2(1f, 0f);
+            warnRect.pivot = new Vector2(0.5f, 0f);
+            warnRect.sizeDelta = new Vector2(-64f, 148f);
+            warnRect.anchoredPosition = new Vector2(0f, 96f);
+
+            var cancel = EcoUIKit.Button(card.transform, "Cancel", 26f, EcoUIKit.Track,
+                                         EcoUIKit.TextMain, Close);
+            var cancelRect = EcoUIKit.Rect(cancel.gameObject);
+            cancelRect.anchorMin = new Vector2(0f, 0f);
+            cancelRect.anchorMax = new Vector2(0.5f, 0f);
+            cancelRect.pivot = new Vector2(0f, 0f);
+            cancelRect.sizeDelta = new Vector2(-40f, 62f);
+            cancelRect.anchoredPosition = new Vector2(32f, 22f);
+
+            var apply = EcoUIKit.Button(card.transform, "Apply", 26f, EcoUIKit.Accent,
+                                        Color.white, Apply);
+            var applyRect = EcoUIKit.Rect(apply.gameObject);
+            applyRect.anchorMin = new Vector2(0.5f, 0f);
+            applyRect.anchorMax = new Vector2(1f, 0f);
+            applyRect.pivot = new Vector2(1f, 0f);
+            applyRect.sizeDelta = new Vector2(-40f, 62f);
+            applyRect.anchoredPosition = new Vector2(-32f, 22f);
+
+            _root = scrim;
+            _root.SetActive(false);
+        }
+
+        void BuildGroup(Transform column, string heading, params TrophicLevel[] levels)
+        {
+            var head = EcoUIKit.Empty(column, "Heading");
+            head.AddComponent<LayoutElement>().preferredHeight = 44f;
+            var text = EcoUIKit.Text(head.transform, heading, 26f, EcoUIKit.TextDim);
+            EcoUIKit.Stretch(EcoUIKit.Rect(text.gameObject), 0f, 0f);
+
+            var all = SpeciesLibrary.All;
+            for (int i = 0; i < all.Length; i++)
+            {
+                bool inGroup = false;
+                foreach (var level in levels) if (all[i].level == level) inGroup = true;
+                if (!inGroup) continue;
+                BuildRow(column, i);
+            }
+        }
+
+        void BuildRow(Transform column, int species)
+        {
+            var def = SpeciesLibrary.Get(species);
+            var row = EcoUIKit.Empty(column, "Pick_" + def.id);
+            row.AddComponent<LayoutElement>().preferredHeight = 68f;
+
+            var box = EcoUIKit.Panel(row.transform, "Box", EcoUIKit.Track);
+            var boxRect = EcoUIKit.Rect(box);
+            boxRect.anchorMin = new Vector2(0f, 0.5f);
+            boxRect.anchorMax = new Vector2(0f, 0.5f);
+            boxRect.pivot = new Vector2(0f, 0.5f);
+            boxRect.sizeDelta = new Vector2(40f, 40f);
+            boxRect.anchoredPosition = new Vector2(4f, 0f);
+            _checkBoxes[species] = box.GetComponent<Image>();
+
+            // A filled inner square, not a tick glyph. LiberationSans has no U+2713,
+            // so "✓" renders as a missing-glyph box.
+            var mark = EcoUIKit.Panel(box.transform, "Mark", Color.white);
+            var markRect = EcoUIKit.Rect(mark);
+            EcoUIKit.Stretch(markRect, 11f, 11f);
+            _checkMarks[species] = mark;
+
+            // Common name on the upper half, scientific name on the lower. These two
+            // were anchored to overlapping bands and printed on top of each other.
+            var label = EcoUIKit.Text(row.transform, def.commonName, 25f, EcoUIKit.TextMain);
+            var labelRect = EcoUIKit.Rect(label.gameObject);
+            labelRect.anchorMin = new Vector2(0f, 1f);
+            labelRect.anchorMax = new Vector2(1f, 1f);
+            labelRect.pivot = new Vector2(0f, 1f);
+            labelRect.offsetMin = new Vector2(58f, -34f);
+            labelRect.offsetMax = new Vector2(-8f, -4f);
+
+            var sci = EcoUIKit.Text(row.transform, def.scientificName, 18f, EcoUIKit.TextDim);
+            sci.fontStyle = FontStyles.Italic;
+            var sciRect = EcoUIKit.Rect(sci.gameObject);
+            sciRect.anchorMin = new Vector2(0f, 0f);
+            sciRect.anchorMax = new Vector2(1f, 0f);
+            sciRect.pivot = new Vector2(0f, 0f);
+            sciRect.offsetMin = new Vector2(58f, 4f);
+            sciRect.offsetMax = new Vector2(-8f, 26f);
+
+            var button = row.AddComponent<Button>();
+            var hit = row.AddComponent<Image>();
+            hit.color = new Color(0f, 0f, 0f, 0f);
+            button.targetGraphic = hit;
+            int index = species;
+            button.onClick.AddListener(() =>
+            {
+                _draft[index] = !_draft[index];
+                PaintRow(index);
+                PaintWarnings();
+            });
+        }
+
+        void PaintRow(int species)
+        {
+            bool on = _draft[species];
+            _checkBoxes[species].color = on ? EcoUIKit.Accent : EcoUIKit.Track;
+            _checkMarks[species].SetActive(on);
+        }
+
+        void PaintWarnings()
+        {
+            var list = EcosystemWarnings.For(_draft);
+            if (list.Count == 0)
+            {
+                _warnings.text = "";
+                return;
+            }
+            var sb = new StringBuilder();
+            for (int i = 0; i < list.Count && i < 3; i++)
+                sb.Append("• ").Append(list[i]).Append(i < list.Count - 1 ? "\n" : "");
+            _warnings.text = sb.ToString();
+        }
+
+        public void Open()
+        {
+            for (int i = 0; i < SpeciesLibrary.Count; i++)
+            {
+                _draft[i] = _reef.Sim.IsPresent(i);
+                PaintRow(i);
+            }
+            PaintWarnings();
+            _root.SetActive(true);
+        }
+
+        public void Close() => _root.SetActive(false);
+
+        void Apply()
+        {
+            for (int i = 0; i < SpeciesLibrary.Count; i++)
+                _reef.SetSpeciesPresent(i, _draft[i]);
+            Close();
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/UI/OrganismPickerUI.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/UI/OrganismPickerUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e94dd310d2b9fb34b9cf045ac64ff31a

--- a/Assets/Scripts/LivingEcosystem/UI/WelcomeBackUI.cs
+++ b/Assets/Scripts/LivingEcosystem/UI/WelcomeBackUI.cs
@@ -1,0 +1,136 @@
+using System.Text;
+using CreateEnv.Ecosystem.Memory;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace CreateEnv.Ecosystem.UI
+{
+    // "While you were away" (Design Document 8.2).
+    //
+    // At most four lines, ranked so births, deaths and new generations always beat a
+    // percentage change in biomass — a card that opens with "the fan alga is down
+    // four percent" when a whole generation hatched has buried the story.
+    //
+    // Skipped entirely for a short absence. Coming back after ten minutes to be told
+    // that nothing much happened is worse than not being told anything.
+    public class WelcomeBackUI : MonoBehaviour
+    {
+        LivingReefController _reef;
+        GameObject _root;
+        TMP_Text _title, _body;
+
+        public System.Action onWhyRequested;
+
+        public static WelcomeBackUI Create(Transform parent, LivingReefController reef)
+        {
+            var host = EcoUIKit.Empty(parent, "WelcomeBack");
+            EcoUIKit.Stretch(EcoUIKit.Rect(host), 0f, 0f);
+
+            var ui = host.AddComponent<WelcomeBackUI>();
+            ui._reef = reef;
+            ui.Build(host.transform);
+            return ui;
+        }
+
+        void Build(Transform parent)
+        {
+            var scrim = EcoUIKit.Panel(parent, "Scrim", new Color(0f, 0f, 0f, 0.72f));
+            EcoUIKit.Stretch(EcoUIKit.Rect(scrim), 0f, 0f);
+
+            var card = EcoUIKit.Panel(scrim.transform, "Card", EcoUIKit.PanelBgSoft);
+            var cardRect = EcoUIKit.Rect(card);
+            cardRect.anchorMin = new Vector2(0.5f, 0.5f);
+            cardRect.anchorMax = new Vector2(0.5f, 0.5f);
+            cardRect.pivot = new Vector2(0.5f, 0.5f);
+            cardRect.sizeDelta = new Vector2(880f, 720f);
+
+            _title = EcoUIKit.Text(card.transform, "While you were away", 34f, EcoUIKit.TextMain);
+            var titleRect = EcoUIKit.Rect(_title.gameObject);
+            titleRect.anchorMin = new Vector2(0f, 1f);
+            titleRect.anchorMax = new Vector2(1f, 1f);
+            titleRect.pivot = new Vector2(0.5f, 1f);
+            titleRect.sizeDelta = new Vector2(-72f, 48f);
+            titleRect.anchoredPosition = new Vector2(0f, -34f);
+
+            _body = EcoUIKit.Text(card.transform, "", 25f, EcoUIKit.TextMain);
+            var bodyRect = EcoUIKit.Rect(_body.gameObject);
+            bodyRect.anchorMin = Vector2.zero;
+            bodyRect.anchorMax = Vector2.one;
+            bodyRect.offsetMin = new Vector2(44f, 118f);
+            bodyRect.offsetMax = new Vector2(-44f, -96f);
+
+            var why = EcoUIKit.Button(card.transform, "Why?", 24f, EcoUIKit.Track,
+                                      EcoUIKit.TextMain,
+                                      () => { Close(); onWhyRequested?.Invoke(); });
+            var whyRect = EcoUIKit.Rect(why.gameObject);
+            whyRect.anchorMin = new Vector2(0f, 0f);
+            whyRect.anchorMax = new Vector2(0.42f, 0f);
+            whyRect.pivot = new Vector2(0f, 0f);
+            whyRect.sizeDelta = new Vector2(-44f, 58f);
+            whyRect.anchoredPosition = new Vector2(44f, 34f);
+
+            var dive = EcoUIKit.Button(card.transform, "Dive back in", 24f, EcoUIKit.Accent,
+                                       Color.white, Close);
+            var diveRect = EcoUIKit.Rect(dive.gameObject);
+            diveRect.anchorMin = new Vector2(0.42f, 0f);
+            diveRect.anchorMax = new Vector2(1f, 0f);
+            diveRect.pivot = new Vector2(1f, 0f);
+            diveRect.sizeDelta = new Vector2(-44f, 58f);
+            diveRect.anchoredPosition = new Vector2(-44f, 34f);
+
+            _root = scrim;
+            _root.SetActive(false);
+        }
+
+        public void Close()
+        {
+            _root.SetActive(false);
+            _reef.ClearReport();
+        }
+
+        public bool ShowIfDue()
+        {
+            if (!_reef.HasSomethingToReport) return false;
+
+            var away = _reef.Resumed;
+            var sb = new StringBuilder();
+
+            int days = away.daysToRun;
+            sb.Append("<size=115%>")
+              .Append(days == 1 ? "A day passed in your ocean." : $"{days} days passed in your ocean.")
+              .Append("</size>\n");
+
+            if (away.wasCapped)
+            {
+                // Saying the cap out loud, rather than quietly applying it. A learner
+                // returning after a month should not have to wonder why their reef is
+                // only a fortnight older.
+                sb.Append("<color=#9FB2C4>You were away about ")
+                  .Append(Mathf.RoundToInt((float)(away.hoursAway / 24.0)))
+                  .Append(" days. An hour away is a day in your ocean, up to two weeks — ")
+                  .Append("so it advanced by the full fortnight and waited for you.</color>\n");
+            }
+            sb.Append('\n');
+
+            var notable = _reef.Chronicle.journal.Notable(_reef.DayOnArrival, 4);
+            if (notable.Count == 0)
+            {
+                sb.Append("Nothing much changed. The reef held steady.");
+            }
+            else
+            {
+                foreach (var e in notable)
+                {
+                    string line = ReefJournal.Describe(e, _reef.Octopuses);
+                    if (!string.IsNullOrEmpty(line))
+                        sb.Append("•  ").Append(line).Append('\n');
+                }
+            }
+
+            _body.text = sb.ToString();
+            _root.SetActive(true);
+            return true;
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/UI/WelcomeBackUI.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/UI/WelcomeBackUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 69156c81b80517e41a861370c750f23b

--- a/Assets/Scripts/LivingEcosystem/UI/WhyPanelUI.cs
+++ b/Assets/Scripts/LivingEcosystem/UI/WhyPanelUI.cs
@@ -1,0 +1,175 @@
+using System.Text;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace CreateEnv.Ecosystem.UI
+{
+    // The Why panel (Design Document 6.2). Every change the learner can see must
+    // have an explanation available in one tap. Answers three questions in plain
+    // language: what is happening, why is it happening, what happens next.
+    //
+    // Doubles as the organism inspector: tapping a species row opens its card, which
+    // extends the info card the app already uses rather than inventing a new one.
+    public class WhyPanelUI : MonoBehaviour
+    {
+        LivingReefController _reef;
+        GameObject _root;
+        TMP_Text _title, _body;
+        RectTransform _content;
+
+        public static WhyPanelUI Create(Transform parent, LivingReefController reef)
+        {
+            var host = EcoUIKit.Empty(parent, "WhyPanel");
+            var rect = EcoUIKit.Rect(host);
+            EcoUIKit.Stretch(rect, 0f, 0f);
+
+            var ui = host.AddComponent<WhyPanelUI>();
+            ui._reef = reef;
+            ui.Build(host.transform);
+            return ui;
+        }
+
+        void Build(Transform parent)
+        {
+            // Dimmed backdrop; tapping it closes.
+            var scrim = EcoUIKit.Panel(parent, "Scrim", new Color(0f, 0f, 0f, 0.62f));
+            EcoUIKit.Stretch(EcoUIKit.Rect(scrim), 0f, 0f);
+            var scrimButton = scrim.AddComponent<Button>();
+            scrimButton.targetGraphic = scrim.GetComponent<Image>();
+            scrimButton.onClick.AddListener(Close);
+
+            var card = EcoUIKit.Panel(scrim.transform, "Card", EcoUIKit.PanelBgSoft);
+            var cardRect = EcoUIKit.Rect(card);
+            cardRect.anchorMin = new Vector2(0.5f, 0.5f);
+            cardRect.anchorMax = new Vector2(0.5f, 0.5f);
+            cardRect.pivot = new Vector2(0.5f, 0.5f);
+            cardRect.sizeDelta = new Vector2(880f, 1080f);
+
+            _title = EcoUIKit.Text(card.transform, "Why?", 36f, EcoUIKit.TextMain);
+            var titleRect = EcoUIKit.Rect(_title.gameObject);
+            titleRect.anchorMin = new Vector2(0f, 1f);
+            titleRect.anchorMax = new Vector2(1f, 1f);
+            titleRect.pivot = new Vector2(0.5f, 1f);
+            titleRect.sizeDelta = new Vector2(-64f, 56f);
+            titleRect.anchoredPosition = new Vector2(0f, -28f);
+
+            var scrollHost = EcoUIKit.Empty(card.transform, "Scroll");
+            var scrollRect = EcoUIKit.Rect(scrollHost);
+            scrollRect.anchorMin = new Vector2(0f, 0f);
+            scrollRect.anchorMax = new Vector2(1f, 1f);
+            scrollRect.offsetMin = new Vector2(40f, 116f);
+            scrollRect.offsetMax = new Vector2(-40f, -104f);
+
+            _content = EcoUIKit.ScrollColumn(scrollHost.transform, out _);
+            EcoUIKit.Stretch(EcoUIKit.Rect(_content.parent.gameObject), 0f, 0f);
+
+            _body = EcoUIKit.Text(_content, "", 25f, EcoUIKit.TextMain);
+            var bodyFitter = _body.gameObject.AddComponent<ContentSizeFitter>();
+            bodyFitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+            _body.gameObject.AddComponent<LayoutElement>().minHeight = 60f;
+
+            var close = EcoUIKit.Button(card.transform, "Close", 26f, EcoUIKit.Accent, Color.white, Close);
+            var closeRect = EcoUIKit.Rect(close.gameObject);
+            closeRect.anchorMin = new Vector2(0.5f, 0f);
+            closeRect.anchorMax = new Vector2(0.5f, 0f);
+            closeRect.pivot = new Vector2(0.5f, 0f);
+            closeRect.sizeDelta = new Vector2(320f, 62f);
+            closeRect.anchoredPosition = new Vector2(0f, 24f);
+
+            _root = scrim;
+            _root.SetActive(false);
+        }
+
+        public void Close() => _root.SetActive(false);
+
+        // The three-question explanation of the reef's current state.
+        public void Open()
+        {
+            _title.text = "Why?";
+            var sb = new StringBuilder();
+            var reasons = _reef.Reasons.Active;
+
+            if (reasons.Count == 0)
+            {
+                sb.Append("Nothing notable is happening yet. Give it a few days, or change something.");
+            }
+            else
+            {
+                for (int i = 0; i < reasons.Count; i++)
+                {
+                    var r = reasons[i];
+                    sb.Append("<b>What is happening</b>\n").Append(r.whatIsHappening).Append("\n\n");
+                    sb.Append("<b>Why</b>\n").Append(r.whyItIsHappening).Append("\n\n");
+                    sb.Append("<b>What happens next</b>\n").Append(r.whatHappensNext);
+                    if (i < reasons.Count - 1) sb.Append("\n\n<color=#5A6C7C>———</color>\n\n");
+                }
+            }
+
+            _body.text = sb.ToString();
+            _root.SetActive(true);
+        }
+
+        // The organism inspector: what this species is, and what it is doing here.
+        public void OpenSpecies(int species)
+        {
+            var def = SpeciesLibrary.Get(species);
+            if (def == null) return;
+
+            var sim = _reef.Sim;
+            _title.text = def.commonName;
+
+            var sb = new StringBuilder();
+            sb.Append("<i>").Append(def.scientificName).Append("</i>\n\n");
+
+            sb.Append("<b>In your reef right now</b>\n");
+            if (!sim.IsPresent(species))
+            {
+                sb.Append("Removed. It is not part of this ecosystem.\n\n");
+            }
+            else
+            {
+                float amount = sim.DisplayAmount(species);
+                sb.Append(def.IsProducer ? "Biomass: " : "Number: ")
+                  .Append(Mathf.RoundToInt(amount));
+
+                int dir = _reef.Reasons.TrendOf(species);
+                sb.Append(dir > 0 ? "  (rising)" : dir < 0 ? "  (falling)" : "  (steady)");
+
+                if (sim.pools[species].bleached) sb.Append("\nBleached — the water is too warm.");
+                if (!def.IsProducer && sim.pools[species].daysHungry >= 5)
+                    sb.Append("\nUnderfed for ").Append(sim.pools[species].daysHungry).Append(" days.");
+                sb.Append("\n\n");
+            }
+
+            sb.Append("<b>Level</b>\n").Append(LevelName(def.level)).Append("\n\n");
+            sb.Append("<b>What it looks like</b>\n").Append(def.appearance).Append("\n\n");
+            sb.Append("<b>Where it lives</b>\n").Append(def.habitat).Append("\n\n");
+            sb.Append("<b>What it eats</b>\n").Append(def.diet).Append("\n\n");
+            sb.Append("<b>Its role here</b>\n").Append(def.roleInModel).Append("\n\n");
+
+            // Conservation status and regional protection as separate labelled
+            // fields — pre-release checklist item 3.
+            sb.Append("<b>IUCN Red List</b>\n").Append(def.iucnStatus).Append("\n\n");
+            if (!string.IsNullOrEmpty(def.regionalStatus))
+                sb.Append("<b>Regionally</b>\n").Append(def.regionalStatus).Append("\n\n");
+
+            sb.Append("<b>Worth knowing</b>\n").Append(def.oneThingWorthTelling).Append("\n\n");
+
+            if (!string.IsNullOrEmpty(def.simplificationNote))
+                sb.Append("<color=#9FB2C4><b>What this simulation simplifies</b>\n")
+                  .Append(def.simplificationNote).Append("</color>");
+
+            _body.text = sb.ToString();
+            _root.SetActive(true);
+        }
+
+        static string LevelName(TrophicLevel level) => level switch
+        {
+            TrophicLevel.Producer    => "Producer — it makes its own food from sunlight",
+            TrophicLevel.PlantEater  => "Plant eater — it eats producers",
+            TrophicLevel.Hunter      => "Hunter — it eats plant eaters",
+            _                        => "Top predator — nothing here regularly hunts it",
+        };
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/UI/WhyPanelUI.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/UI/WhyPanelUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 67c9872c90d0c92428b0b1165ddfb9f6

--- a/Assets/Scripts/LivingEcosystem/View.meta
+++ b/Assets/Scripts/LivingEcosystem/View.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ff6c1f6535b886c4ea7edb2f6803e73a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/LivingEcosystem/View/PopulationRenderer.cs
+++ b/Assets/Scripts/LivingEcosystem/View/PopulationRenderer.cs
@@ -1,0 +1,694 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem
+{
+    // Simulate numbers, draw a sample (Design Document 3.1).
+    //
+    // The renderer draws as many models as the visual budget allows and scales that
+    // to the pool. If forty parrotfish exist and the cap is eight, eight are drawn
+    // and the true count is shown on screen. If the pool crashes to three, three are
+    // drawn.
+    //
+    // Everything is pooled: instances are created once, then shown, hidden and moved.
+    // No allocation and no Instantiate after warm-up, which is what keeps this off
+    // the frame budget on a 4 GB Android device.
+    public class PopulationRenderer : MonoBehaviour
+    {
+        [Tooltip("Hard ceiling on models drawn across all species at once. The design " +
+                 "document's figure was 30, set before the models existed; the whole " +
+                 "roster is only 2,524 triangles, so 48 costs about 12k triangles and " +
+                 "buys a reef that actually looks inhabited.")]
+        public int totalModelBudget = 48;
+
+        [Tooltip("Radius around the learner within which models are placed.")]
+        public float placementRadius = 8f;
+
+        [Tooltip("Display scale on every organism. Life-size is biologically honest " +
+                 "but reads as specks against terrain whose dunes are tens of metres " +
+                 "across, so the drawn size is lifted a little. This is a disclosed " +
+                 "simplification, like the compressed time and brood sizes.")]
+        public float sizeMultiplier = 1.8f;
+
+        [Tooltip("How often the drawn sample is rebuilt, in seconds. The simulation " +
+                 "ticks far faster than the eye needs the crowd redrawn.")]
+        public float refreshInterval = 1.5f;
+
+        [Tooltip("Centre the reef on the learner, which is what AR wants. Turn this " +
+                 "off to pin it to this object instead, for a fixed-camera preview " +
+                 "where a reef centred on the camera would be half behind it.")]
+        public bool followViewer = true;
+
+        [Tooltip("Draw nothing until there is a seafloor to stand on. In AR the " +
+                 "environment is not placed until the learner taps a surface, and " +
+                 "organisms hanging in mid-air over the camera feed before that just " +
+                 "look broken.")]
+        public bool requireGround = true;
+
+        // Set when the octopuses have been promoted to individuals with genomes, so
+        // every one of them is drawn and wears its own genotype.
+        [System.NonSerialized] public Genetics.OctopusPopulation octopuses;
+
+        // Lets the renderer see which octopuses the learner has singled out.
+        [System.NonSerialized] public LivingReefController reef;
+
+        static readonly RaycastHit[] _hitBuffer = new RaycastHit[16];
+        readonly float[] _weightScratch = new float[SpeciesLibrary.Count];
+
+        // Finds the seabed under a point, ignoring the AR session's own planes.
+        //
+        // Those planes carry colliders, and they are the real-world floor the
+        // environment was placed on — not the seafloor the organisms live on. Taking
+        // the first hit put the whole reef on the detected plane instead of the
+        // terrain, and made the reef appear before the environment had been placed at
+        // all, because a scanned plane counted as ground.
+        static bool TryFindSeabed(Vector3 above, out float y, out Vector3 normal)
+        {
+            y = 0f;
+            normal = Vector3.up;
+
+            int count = Physics.RaycastNonAlloc(above, Vector3.down, _hitBuffer, 240f);
+            float nearest = float.MaxValue;
+            bool found = false;
+
+            for (int i = 0; i < count; i++)
+            {
+                var hit = _hitBuffer[i];
+                if (hit.collider == null) continue;
+                if (hit.collider.GetComponentInParent<UnityEngine.XR.ARFoundation.ARPlane>() != null)
+                    continue;
+
+                if (hit.distance < nearest)
+                {
+                    nearest = hit.distance;
+                    y = hit.point.y;
+                    normal = hit.normal;
+                    found = true;
+                }
+            }
+            return found;
+        }
+
+        class Instance
+        {
+            public GameObject go;
+            public Transform tf;
+            public Vector3 anchor;
+            public float phase;
+            public float swimSpeed;
+            public MotionKind motion;
+            public float roamRadius;
+            public float verticalRoam;
+            public Quaternion groundTilt;   // the slope this one is lying on
+            public bool seated;       // has it been given a home yet
+            public Quaternion seatedRotation;
+            public float groundY;   // seabed height directly under this model
+            public float ceilingY;  // the top of its usable water column
+            public float bottomOffset; // origin down to the model's lowest point
+            public float topOffset;    // origin up to its highest point
+            public float baseScale;    // the size this model was normalised to
+            public Genetics.OctopusAgentView view;   // octopuses only
+            public int agentId = -1;                 // octopuses only
+            public Genetics.OctopusAgent agent;      // resolved once per rebuild
+            public bool denned;                      // she has settled to brood
+        }
+
+        readonly List<Instance>[] _instances = new List<Instance>[SpeciesLibrary.Count];
+        readonly int[] _visible = new int[SpeciesLibrary.Count];
+
+        EcosystemSimulation _sim;
+        Transform _origin;
+        float _refreshTimer;
+        float _patchTimer;
+        int _placementSeed = 977;
+
+        // Where this patch of reef sits. Fixed once found, so the organisms stay put
+        // instead of chasing the camera around. It only moves if the learner walks a
+        // long way, or when the seafloor first appears underneath them — in AR the
+        // environment is placed by a tap some time after this component starts, and
+        // until then there is no ground to sit on.
+        Vector3 _patchCentre;
+        bool _patchPlaced;
+        bool _hadGround;
+        WaterSurface _water;
+        bool _loggedColumn;
+
+        public void Bind(EcosystemSimulation sim, Transform origin)
+        {
+            _sim = sim;
+            _origin = origin != null ? origin : transform;
+            for (int i = 0; i < _instances.Length; i++)
+                _instances[i] ??= new List<Instance>(8);
+            _refreshTimer = 0f;
+            Rebuild();
+        }
+
+        void Update()
+        {
+            if (_sim == null) return;
+
+            _patchTimer -= Time.deltaTime;
+            if (_patchTimer <= 0f)
+            {
+                _patchTimer = 0.25f;
+                UpdatePatchCentre();
+            }
+
+            _refreshTimer -= Time.deltaTime;
+            if (_refreshTimer <= 0f)
+            {
+                _refreshTimer = refreshInterval;
+                Rebuild();
+            }
+
+            Animate();
+        }
+
+        // Decides where the patch of reef lives, and only moves it when it has to.
+        void UpdatePatchCentre()
+        {
+            Vector3 viewer = _origin != null ? _origin.position : transform.position;
+            if (followViewer)
+            {
+                var cam = Camera.main;
+                if (cam != null) viewer = cam.transform.position;
+            }
+
+            bool hasGround = TryFindSeabed(viewer + Vector3.up * 30f, out float seabed, out _);
+            float ground = hasGround ? seabed : viewer.y - 2.5f;
+
+            // First frame, or the learner has walked out of this patch, or the
+            // seafloor has just been placed under them.
+            // Ground appearing for the first time counts (in AR the seafloor only
+            // exists after the learner taps to place it). Ground going away does not,
+            // or a chunk dropping its collider at distance would shuffle the reef.
+            bool groundJustArrived = hasGround && !_hadGround;
+
+            bool needsMove = !_patchPlaced
+                          || groundJustArrived
+                          || Vector3.Distance(new Vector3(viewer.x, 0f, viewer.z),
+                                              new Vector3(_patchCentre.x, 0f, _patchCentre.z)) > placementRadius * 1.4f;
+
+            if (!needsMove) return;
+
+            _patchCentre = new Vector3(viewer.x, ground, viewer.z);
+            _patchPlaced = true;
+            _hadGround = hasGround;
+
+            if (!_loggedColumn && hasGround)
+            {
+                _loggedColumn = true;
+                Debug.Log($"[LivingReef] Seabed found at y={ground:0.00} (AR planes excluded). " +
+                          $"Water surface reports y={SurfaceHeight():0.00}.");
+            }
+
+            // Everything currently out there needs a new home around the new centre.
+            for (int s = 0; s < _instances.Length; s++)
+            {
+                var list = _instances[s];
+                if (list == null) continue;
+                for (int i = 0; i < list.Count; i++) list[i].seated = false;
+            }
+        }
+
+        // Decides how many of each species to draw, then shows exactly that many.
+        void Rebuild()
+        {
+            if (_sim == null) return;
+
+            // Nothing to stand on yet — the environment has not been placed.
+            if (requireGround && !_hadGround)
+            {
+                for (int i = 0; i < SpeciesLibrary.Count; i++) SetVisible(i, 0);
+                return;
+            }
+
+            var all = SpeciesLibrary.All;
+
+            // Share the budget by each species' share of the drawn population, so a
+            // species that has crashed visibly thins out instead of holding its slots.
+            float totalWeight = 0f;
+            var weight = _weightScratch;
+            for (int i = 0; i < all.Length; i++) weight[i] = 0f;
+            for (int i = 0; i < all.Length; i++)
+            {
+                if (!_sim.IsAlive(i)) continue;
+                float amount = _sim.DisplayAmount(i);
+                float per = Mathf.Max(0.01f, all[i].individualsPerModel);
+                weight[i] = Mathf.Sqrt(Mathf.Max(0f, amount / per));
+                totalWeight += weight[i];
+            }
+
+            for (int i = 0; i < all.Length; i++)
+            {
+                int want = 0;
+
+                // Octopuses are individuals, not a sample. Every living one is drawn,
+                // because the learner taps them, inspects them and breeds them — a
+                // representative crowd would be meaningless.
+                if (i == SpeciesLibrary.Octopus && octopuses != null)
+                {
+                    want = Mathf.Min(octopuses.AliveCount, totalModelBudget);
+                }
+                else if (_sim.IsAlive(i) && totalWeight > 0f)
+                {
+                    float amount = _sim.DisplayAmount(i);
+                    float per = Mathf.Max(0.01f, all[i].individualsPerModel);
+
+                    // Never draw more than actually exist, never fewer than one while
+                    // any remain: a single surviving animal must still be visible.
+                    int trueish = Mathf.CeilToInt(amount / per);
+                    int share = Mathf.RoundToInt(totalModelBudget * (weight[i] / totalWeight));
+                    want = Mathf.Clamp(Mathf.Min(share, trueish), 1, totalModelBudget);
+                }
+                SetVisible(i, want);
+            }
+
+            ApplyOctopusGenomes();
+        }
+
+        // Gives each drawn octopus the size and colour its own genes call for.
+        void ApplyOctopusGenomes()
+        {
+            if (octopuses == null) return;
+
+            var list = _instances[SpeciesLibrary.Octopus];
+            if (list == null) return;
+
+            var def = SpeciesLibrary.Get(SpeciesLibrary.Octopus);
+            float baseScale = def != null ? def.modelHeightMeters * sizeMultiplier : 1f;
+
+            int shown = 0;
+            for (int i = 0; i < octopuses.agents.Count && shown < list.Count; i++)
+            {
+                var agent = octopuses.agents[i];
+                if (!agent.IsAlive) continue;
+
+                var view = list[shown].view;
+                if (view != null) view.Apply(agent, list[shown].baseScale);
+                list[shown].agentId = agent.id;
+                list[shown].agent = agent;
+                if (!agent.IsBrooding) list[shown].denned = false;
+
+                if (view != null)
+                {
+                    bool chosen = reef != null &&
+                                  (agent.id == reef.chosenFemaleId || agent.id == reef.chosenMaleId);
+                    // A chosen animal is lit steadily; a brooding one keeps a fainter
+                    // light so she can still be found once the tool is closed.
+                    view.SetGlow(chosen ? 1f : agent.IsBrooding ? 0.35f : 0f);
+                }
+
+                shown++;
+            }
+        }
+
+        void SetVisible(int species, int wanted)
+        {
+            var list = _instances[species];
+            if (list == null) return;
+
+            while (list.Count < wanted)
+            {
+                var inst = Create(species, list.Count);
+                if (inst == null) break;
+                list.Add(inst);
+            }
+
+            for (int i = 0; i < list.Count; i++)
+            {
+                bool on = i < wanted;
+                if (list[i].go.activeSelf != on) list[i].go.SetActive(on);
+
+                // Only place a model when it first appears, or after the patch has
+                // moved. Re-seating every refresh is what made them teleport.
+                if (on && !list[i].seated)
+                {
+                    Reseat(species, list[i], i);
+                    list[i].seated = true;
+                }
+            }
+
+            _visible[species] = Mathf.Min(wanted, list.Count);
+        }
+
+        Instance Create(int species, int index)
+        {
+            var def = SpeciesLibrary.Get(species);
+            if (def == null) return null;
+
+            GameObject go;
+            var prefab = SpeciesVisualLibrary.PrefabFor(species);
+            if (prefab != null)
+            {
+                go = Instantiate(prefab, transform);
+            }
+            else
+            {
+                var mesh = SpeciesVisualLibrary.MeshFor(species);
+                if (mesh == null) return null;
+
+                go = new GameObject($"{def.id}_{index}");
+                go.transform.SetParent(transform, false);
+                go.AddComponent<MeshFilter>().sharedMesh = mesh;
+
+                var mr = go.AddComponent<MeshRenderer>();
+                mr.sharedMaterial = SpeciesVisualLibrary.MaterialFor(species);
+                mr.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+                mr.receiveShadows = false;
+                mr.lightProbeUsage = UnityEngine.Rendering.LightProbeUsage.Off;
+                mr.reflectionProbeUsage = UnityEngine.Rendering.ReflectionProbeUsage.Off;
+            }
+
+            go.name = $"{def.id}_{index}";
+            // Scaled against the environment the reef is sitting in, so the organisms
+            // keep the right size relative to the world however it was placed.
+            float worldScale = _origin != null ? Mathf.Max(0.01f, _origin.lossyScale.x) : 1f;
+            float targetSize = def.modelHeightMeters * sizeMultiplier * worldScale;
+            NormaliseSize(go, targetSize);
+            float normalisedScale = go.transform.localScale.x;
+
+            Genetics.OctopusAgentView view = null;
+            if (species == SpeciesLibrary.Octopus)
+            {
+                view = go.AddComponent<Genetics.OctopusAgentView>();
+                view.Bind(go.GetComponentInChildren<Renderer>(), def.tint);
+
+                // Something to tap. Sized to the model so it is comfortable to hit on
+                // a phone without swallowing taps meant for the interface.
+                var collider = go.AddComponent<SphereCollider>();
+                collider.radius = 0.62f;
+                collider.isTrigger = true;
+            }
+
+            // Measure the scaled model so it can be seated on the seabed by its
+            // underside rather than by its centre.
+            go.transform.localPosition = Vector3.zero;
+            float bottomOffset = 0f, topOffset = 0f;
+            if (TryCombinedBounds(go, out var bounds))
+            {
+                bottomOffset = go.transform.position.y - bounds.min.y;
+                topOffset = bounds.max.y - go.transform.position.y;
+            }
+
+            var rng = new System.Random(_placementSeed + species * 131 + index);
+            return new Instance
+            {
+                go = go,
+                tf = go.transform,
+                motion = def.motion,
+                roamRadius = Mathf.Max(0.05f, def.roamRadius),
+                verticalRoam = def.verticalRoam,
+
+                bottomOffset = bottomOffset,
+                topOffset = topOffset,
+                phase = (float)rng.NextDouble() * Mathf.PI * 2f,
+                swimSpeed = 0.25f + (float)rng.NextDouble() * 0.35f,
+                baseScale = normalisedScale,
+                view = view,
+            };
+        }
+
+        // Scales whatever the model happens to be so it stands the right number of
+        // metres tall, regardless of its native import size.
+        static void NormaliseSize(GameObject go, float targetHeight)
+        {
+            if (targetHeight <= 0f) return;
+            if (!TryCombinedBounds(go, out var bounds)) return;
+
+            float h = Mathf.Max(bounds.size.x, Mathf.Max(bounds.size.y, bounds.size.z));
+            if (h <= 1e-4f) return;
+
+            go.transform.localScale *= targetHeight / h;
+        }
+
+        static bool TryCombinedBounds(GameObject go, out Bounds bounds)
+        {
+            bounds = default;
+            var renderers = go.GetComponentsInChildren<Renderer>();
+            if (renderers.Length == 0) return false;
+
+            bounds = renderers[0].bounds;
+            for (int i = 1; i < renderers.Length; i++) bounds.Encapsulate(renderers[i].bounds);
+            return true;
+        }
+
+        // World height of the water surface, so swimmers can be layered against the
+        // real column. Falls back to a sensible ceiling when there is no water plane.
+        float _waterSearch;
+
+        float SurfaceHeight()
+        {
+            // Looked for occasionally rather than on every call: FindFirstObjectByType
+            // is expensive, and in a scene with no water plane the old code paid for
+            // it every single time a model was seated.
+            if (_water == null && Time.time >= _waterSearch)
+            {
+                _waterSearch = Time.time + 2f;
+                _water = FindFirstObjectByType<WaterSurface>();
+            }
+            if (_water != null) return _water.transform.position.y;
+            return _patchCentre.y + 8f;
+        }
+
+        // Places one model somewhere plausible on the patch: sessile life sits on the
+        // seafloor, swimmers hold station above it. Deterministic per species and
+        // slot, so the same reef lays out the same way twice.
+        void Reseat(int species, Instance inst, int index)
+        {
+            var def = SpeciesLibrary.Get(species);
+            if (def == null) return;
+
+            var rng = new System.Random(_placementSeed + species * 733 + index * 17);
+
+            float angle = (float)rng.NextDouble() * Mathf.PI * 2f;
+            // sqrt keeps the scatter even across the disc instead of clumping at the
+            // centre, and the inner hole keeps models out of the learner's face.
+            float radius = Mathf.Lerp(1.8f, placementRadius, Mathf.Sqrt((float)rng.NextDouble()));
+
+            Vector3 flat = _patchCentre + new Vector3(Mathf.Cos(angle) * radius, 0f,
+                                                      Mathf.Sin(angle) * radius);
+
+            // Sit on the seafloor directly beneath this spot, so the reef follows the
+            // real terrain instead of floating on one flat plane, and pick up the
+            // slope there so attached life can lie along it.
+            float groundY = _patchCentre.y;
+            Vector3 groundNormal = Vector3.up;
+            if (TryFindSeabed(flat + Vector3.up * 30f, out float hitY, out Vector3 hitNormal))
+            {
+                groundY = hitY;
+                groundNormal = hitNormal;
+            }
+
+            // Height above the seabed, in plain metres.
+            //
+            // This deliberately does not derive itself from the water surface.
+            // WaterSurface reports an absolute world height while the terrain sits
+            // wherever the AR tap landed, and when those two disagreed the computed
+            // column collapsed and every swimmer ended up lying on the sand. The
+            // seabed is the one reference that is always right underfoot.
+            float surfaceY = SurfaceHeight();
+
+            float y;
+            Quaternion yaw = Quaternion.Euler(0f, (float)rng.NextDouble() * 360f, 0f);
+
+            if (def.attachedToSeabed)
+            {
+                // Underside on the seabed, not centre — otherwise half the model is
+                // buried in the sand — and lying along whatever slope it is fixed to.
+                y = groundY + inst.bottomOffset;
+                inst.groundTilt = Quaternion.FromToRotation(Vector3.up, groundNormal);
+                inst.tf.rotation = inst.groundTilt * yaw;
+            }
+            else
+            {
+                y = groundY + Mathf.Lerp(def.seabedClearanceMin, def.seabedClearanceMax,
+                                         (float)rng.NextDouble());
+
+                // Never clipping through the seabed. The surface is used only as a
+                // ceiling, and only when it reports something credible.
+                float lowest = groundY + inst.bottomOffset + 0.05f;
+                y = Mathf.Max(y, lowest);
+                if (surfaceY > groundY + 2f)
+                    y = Mathf.Max(lowest, Mathf.Min(y, surfaceY - inst.topOffset - 0.3f));
+
+                inst.groundTilt = Quaternion.identity;
+                inst.tf.rotation = yaw;
+            }
+
+            inst.anchor = new Vector3(flat.x, y, flat.z);
+            inst.tf.position = inst.anchor;
+            inst.seatedRotation = inst.tf.rotation;
+            inst.groundY = groundY;
+            inst.ceilingY = surfaceY > groundY + 2f ? surfaceY : groundY + 60f;
+        }
+
+        // Sessile life sways; swimmers drift around their anchor. Cheap sine motion,
+        // no physics, no pathfinding — enough to stop the reef looking like a
+        // photograph without costing anything measurable.
+        void Animate()
+        {
+            float t = Time.time;
+            for (int s = 0; s < _instances.Length; s++)
+            {
+                var list = _instances[s];
+                if (list == null) continue;
+
+                for (int i = 0; i < _visible[s] && i < list.Count; i++)
+                {
+                    var inst = list[i];
+                    if (!inst.go.activeSelf) continue;
+
+                    if (s == SpeciesLibrary.Octopus && octopuses != null &&
+                        AnimateOctopus(inst, t)) continue;
+
+                    switch (inst.motion)
+                    {
+                        case MotionKind.Fixed:
+                            // A coral colony on a limestone skeleton. It stays put.
+                            break;
+
+                        case MotionKind.Sway:
+                        {
+                            // Rooted, but flexible enough to move with the water.
+                            float sway = Mathf.Sin(t * 0.7f + inst.phase) * 3.5f;
+                            inst.tf.rotation = inst.seatedRotation *
+                                               Quaternion.Euler(sway, 0f, sway * 0.5f);
+                            break;
+                        }
+
+                        case MotionKind.Crawl:
+                        {
+                            // Slow travel over the seabed, staying on the bottom.
+                            float a = t * inst.swimSpeed * 0.38f + inst.phase;
+                            var offset = new Vector3(Mathf.Sin(a) * inst.roamRadius, 0f,
+                                                     Mathf.Cos(a * 0.83f) * inst.roamRadius);
+                            Vector3 next = inst.anchor + offset;
+                            next.y = inst.groundY + inst.bottomOffset;
+
+                            Vector3 travel = next - inst.tf.position;
+                            inst.tf.position = next;
+                            // Face the way it is going, but keep lying on the slope.
+                            if (travel.sqrMagnitude > 1e-8f)
+                            {
+                                var flat = new Vector3(travel.x, 0f, travel.z);
+                                if (flat.sqrMagnitude > 1e-8f)
+                                    inst.tf.rotation = Quaternion.Slerp(inst.tf.rotation,
+                                        inst.groundTilt * Quaternion.LookRotation(flat.normalized, Vector3.up),
+                                        0.05f);
+                            }
+                            break;
+                        }
+
+                        default:
+                        {
+                            float a = t * inst.swimSpeed + inst.phase;
+                            var offset = new Vector3(Mathf.Sin(a) * 1.2f,
+                                                     Mathf.Sin(a * 0.6f) * inst.verticalRoam,
+                                                     Mathf.Cos(a * 0.8f) * 1.2f);
+                            Vector3 next = inst.anchor + offset;
+
+                            // Never through the seabed, never out through the surface.
+                            next.y = Mathf.Clamp(next.y,
+                                                 inst.groundY + inst.bottomOffset,
+                                                 inst.ceilingY - inst.topOffset - 0.15f);
+
+                            Vector3 travel = next - inst.tf.position;
+                            inst.tf.position = next;
+                            if (travel.sqrMagnitude > 1e-6f)
+                                inst.tf.rotation = Quaternion.Slerp(inst.tf.rotation,
+                                    Quaternion.LookRotation(travel.normalized, Vector3.up), 0.15f);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Courtship and brooding, shown rather than described.
+        //
+        // A male that has mated goes to the female he mated with and stays with her
+        // while he fades; she settles into a den on the seabed and stops moving
+        // altogether for the month she is guarding her eggs. Both come straight off
+        // the life cycle the simulation is already running, so what the learner
+        // watches and what is actually happening are the same thing.
+        //
+        // Returns true when it has taken charge of this model's movement.
+        bool AnimateOctopus(Instance inst, float t)
+        {
+            if (inst.agentId < 0) return false;
+
+            // Resolved during the last rebuild rather than searched for every frame.
+            var agent = inst.agent;
+            if (agent == null || !agent.IsAlive || agent.id != inst.agentId) return false;
+
+            if (agent.IsBrooding)
+            {
+                // She picks a den the moment she starts brooding and does not leave it.
+                // She picks a den the moment she starts brooding and does not leave it.
+                if (!inst.denned)
+                {
+                    inst.denned = true;
+                    inst.anchor = new Vector3(inst.anchor.x,
+                                              inst.groundY + inst.bottomOffset,
+                                              inst.anchor.z);
+                }
+
+                inst.tf.position = Vector3.Lerp(inst.tf.position, inst.anchor, 0.06f);
+
+                // Just the slow breathing of an animal fanning its eggs.
+                float breathe = 1f + Mathf.Sin(t * 0.8f + inst.phase) * 0.02f;
+                inst.tf.localScale = Vector3.one * (inst.baseScale * breathe);
+                return true;
+            }
+
+            // A mated male keeps close to his partner for the little time he has left.
+            if (agent.HasMated)
+            {
+                var partner = FindBroodingPartner(agent.id);
+                if (partner.HasValue)
+                {
+                    // He heads for her while he is still crossing the reef and only
+                    // starts circling once he arrives, so the approach reads as an
+                    // approach rather than an orbit that begins from far away.
+                    float distance = Vector3.Distance(inst.tf.position, partner.Value);
+                    float arrived = Mathf.Clamp01(Mathf.InverseLerp(4f, 1.2f, distance));
+
+                    Vector3 orbit = new Vector3(Mathf.Cos(t * 0.4f + inst.phase), 0.35f,
+                                                Mathf.Sin(t * 0.4f + inst.phase)) * 0.9f;
+                    Vector3 beside = partner.Value + orbit * arrived;
+
+                    Vector3 travel = beside - inst.tf.position;
+                    inst.tf.position = Vector3.Lerp(inst.tf.position, beside,
+                                                    Mathf.Lerp(0.012f, 0.05f, arrived));
+                    if (travel.sqrMagnitude > 1e-5f)
+                        inst.tf.rotation = Quaternion.Slerp(inst.tf.rotation,
+                            Quaternion.LookRotation(travel.normalized, Vector3.up), 0.08f);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        // Where the female carrying this male's brood currently is.
+        Vector3? FindBroodingPartner(int maleId)
+        {
+            var list = _instances[SpeciesLibrary.Octopus];
+            if (list == null) return null;
+
+            for (int i = 0; i < list.Count; i++)
+            {
+                if (!list[i].go.activeSelf || list[i].agentId < 0) continue;
+                var other = octopuses.ById(list[i].agentId);
+                if (other == null || !other.IsBrooding) continue;
+                if (other.storedMateId != maleId) continue;
+                return list[i].tf.position;
+            }
+            return null;
+        }
+
+        public int VisibleCount(int species) =>
+            species >= 0 && species < _visible.Length ? _visible[species] : 0;
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/View/PopulationRenderer.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/View/PopulationRenderer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9a6d505b0783f7f4d93cd80344c848b2

--- a/Assets/Scripts/LivingEcosystem/View/ReefMeshLibrary.cs
+++ b/Assets/Scripts/LivingEcosystem/View/ReefMeshLibrary.cs
@@ -1,0 +1,719 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem
+{
+    // Species-shaped meshes for the nine Cabo Verde organisms, built in code.
+    //
+    // These are not placeholders for "some sea creature". Each one is built to the
+    // diagnostic silhouette the Literature Document describes, because a learner is
+    // meant to recognise what they are looking at and read a real trait off it:
+    //
+    //   Halimeda    chains of flat calcified segments   -> it is built of discs
+    //   Padina      banded funnel-shaped blade          -> it is a rolled fan
+    //   Siderastrea low dome pitted with star cups      -> the corallites are modelled
+    //   Parrotfish  deep laterally-compressed body      -> tall and thin, not a tube
+    //   Diadema     small test, very long fine spines   -> spines dominate the shape
+    //   Fissurella  low cone with a hole at the apex    -> the keyhole is really there
+    //   Panulirus   long antennae and NO claws          -> the point of its info card
+    //   Octopus     bulbous mantle, eight arms          -> arms are individually built
+    //   Tiger shark blunt snout, long upper tail lobe   -> the tail is asymmetric
+    //
+    // Everything is low-poly (84 to 452 triangles each, 2,524 for the whole roster),
+    // shaded off normals, with no textures, and built once then shared by every
+    // instance. At the 30-model on-screen cap the worst case is around 13k triangles
+    // and zero texture memory, so the added application size is a rounding error
+    // against the 15 MB budget.
+    //
+    // Verified by the mesh check in the balance report: every species builds valid,
+    // non-degenerate geometry with the right proportions.
+    public static class ReefMeshLibrary
+    {
+        public static Mesh Build(int species, int seed)
+        {
+            var mb = new MeshBuilder();
+            var rng = new System.Random(seed);
+
+            switch (species)
+            {
+                case SpeciesLibrary.Halimeda:   BuildHalimeda(mb, rng);   break;
+                case SpeciesLibrary.Padina:     BuildPadina(mb, rng);     break;
+                case SpeciesLibrary.Coral:      BuildStarletCoral(mb, rng); break;
+                case SpeciesLibrary.Parrotfish: BuildParrotfish(mb);      break;
+                case SpeciesLibrary.Urchin:     BuildUrchin(mb, rng);     break;
+                case SpeciesLibrary.Limpet:     BuildLimpet(mb);          break;
+                case SpeciesLibrary.Lobster:    BuildLobster(mb);         break;
+                case SpeciesLibrary.Octopus:    BuildOctopus(mb, rng);    break;
+                case SpeciesLibrary.TigerShark: BuildTigerShark(mb);      break;
+                default:                        BuildUrchin(mb, rng);     break;
+            }
+
+            return mb.ToMesh("LivingEcosystem/" + SpeciesLibrary.Get(species)?.id);
+        }
+
+        // ── Producers ────────────────────────────────────────────────────────
+
+        // Halimeda: low bushy clumps of branching chains, each chain a run of small
+        // flat segments. The segmented construction is the whole teaching point —
+        // those segments are limestone, and they become the sand.
+        static void BuildHalimeda(MeshBuilder mb, System.Random rng)
+        {
+            int chains = 4 + rng.Next(2);
+            for (int c = 0; c < chains; c++)
+            {
+                float baseAngle = (float)(rng.NextDouble() * Mathf.PI * 2f);
+                float lean = 0.12f + (float)rng.NextDouble() * 0.22f;
+                Vector3 pos = new Vector3(Mathf.Cos(baseAngle) * 0.06f, 0f, Mathf.Sin(baseAngle) * 0.06f);
+                Vector3 dir = new Vector3(Mathf.Cos(baseAngle) * lean, 1f, Mathf.Sin(baseAngle) * lean).normalized;
+
+                int segments = 3 + rng.Next(3);
+                float size = 0.085f;
+                for (int s = 0; s < segments; s++)
+                {
+                    // Each segment is a flat disc, alternating its facing so the chain
+                    // reads as the flattened, articulated thallus it really is.
+                    // Pick the reference axis that is least parallel to the chain, or
+                    // the cross product collapses and the disc degenerates.
+                    Vector3 reference = Mathf.Abs(dir.x) < 0.85f ? Vector3.right : Vector3.forward;
+                    if (s % 2 == 1) reference = Mathf.Abs(dir.z) < 0.85f ? Vector3.forward : Vector3.right;
+                    Vector3 normal = Vector3.Cross(dir, reference).normalized;
+                    if (normal.sqrMagnitude < 0.25f) normal = Vector3.Cross(dir, Vector3.up).normalized;
+                    mb.AddDisc(pos + dir * size * 0.5f, dir, normal, size, size * 0.82f, 5, 0.018f);
+
+                    pos += dir * size * 0.95f;
+                    size *= 0.88f;
+                    // Wander so no two chains look alike.
+                    dir = (dir + new Vector3((float)rng.NextDouble() - 0.5f, 0.25f,
+                                             (float)rng.NextDouble() - 0.5f) * 0.30f).normalized;
+                }
+            }
+        }
+
+        // Padina: thin fan- or funnel-shaped blades with an inrolled upper margin and
+        // fine concentric banding. Built as a rolled fan sheet, double-sided.
+        static void BuildPadina(MeshBuilder mb, System.Random rng)
+        {
+            int blades = 3 + rng.Next(2);
+            for (int b = 0; b < blades; b++)
+            {
+                float yaw = (float)(rng.NextDouble() * Mathf.PI * 2f);
+                float height = 0.55f + (float)rng.NextDouble() * 0.35f;
+                float spread = 1.5f + (float)rng.NextDouble() * 0.9f;   // radians of arc
+                float tilt = 0.15f + (float)rng.NextDouble() * 0.2f;
+
+                const int rings = 4, cols = 6;
+                var grid = new Vector3[rings + 1, cols + 1];
+
+                for (int r = 0; r <= rings; r++)
+                {
+                    float t = r / (float)rings;
+                    float radius = t * height;
+                    // The blade widens as it rises, and curls inward at the margin.
+                    float curl = Mathf.Pow(t, 2.2f) * 0.30f;
+
+                    for (int c = 0; c <= cols; c++)
+                    {
+                        float a = yaw + (c / (float)cols - 0.5f) * spread * t;
+                        float x = Mathf.Cos(a) * radius;
+                        float z = Mathf.Sin(a) * radius;
+                        float y = t * height * (1f - tilt) - curl * 0.25f;
+                        // Pull the rim in toward the axis: the funnel shape.
+                        grid[r, c] = new Vector3(x * (1f - curl), y, z * (1f - curl));
+                    }
+                }
+
+                // Given real thickness rather than built as a zero-thickness sheet.
+                // Two coincident faces pointing opposite ways means one of them always
+                // faces away from the light and renders black, which is why the fan
+                // alga looked inside-out. A thin solid lights correctly from any angle.
+                mb.AddSheet(grid, rings, cols, height * 0.018f);
+            }
+        }
+
+        // Siderastrea radians: a low dome, rarely more than 30 cm across, its surface
+        // deeply pitted with star-shaped cups. Those pits are what the name refers to,
+        // so they are modelled rather than implied.
+        static void BuildStarletCoral(MeshBuilder mb, System.Random rng)
+        {
+            const int rings = 6, segs = 12;
+            float radius = 0.5f, height = 0.30f;
+
+            var grid = new Vector3[rings + 1, segs + 1];
+            for (int r = 0; r <= rings; r++)
+            {
+                float t = r / (float)rings;
+                // Flattened hemisphere: encrusting, not spherical.
+                float ringRadius = Mathf.Sin(t * Mathf.PI * 0.5f) * radius;
+                float y = Mathf.Cos(t * Mathf.PI * 0.5f) * height;
+
+                for (int c = 0; c <= segs; c++)
+                {
+                    float a = c / (float)segs * Mathf.PI * 2f;
+                    // Slight irregularity: it grows over whatever rock it is on.
+                    float bump = 1f + ((float)rng.NextDouble() - 0.5f) * 0.06f;
+                    grid[r, c] = new Vector3(Mathf.Cos(a) * ringRadius * bump, y * bump,
+                                             Mathf.Sin(a) * ringRadius * bump);
+                }
+            }
+
+            for (int r = 0; r < rings; r++)
+                for (int c = 0; c < segs; c++)
+                    mb.AddQuad(grid[r, c], grid[r, c + 1], grid[r + 1, c + 1], grid[r + 1, c]);
+
+            // The corallites: small pits sunk into the dome.
+            int pits = 18;
+            for (int i = 0; i < pits; i++)
+            {
+                float u = (float)rng.NextDouble();
+                float t = Mathf.Sqrt(u) * 0.86f;
+                float a = (float)(rng.NextDouble() * Mathf.PI * 2f);
+                float ringRadius = Mathf.Sin(t * Mathf.PI * 0.5f) * radius;
+                float y = Mathf.Cos(t * Mathf.PI * 0.5f) * height;
+
+                Vector3 centre = new Vector3(Mathf.Cos(a) * ringRadius, y, Mathf.Sin(a) * ringRadius);
+                Vector3 outward = centre.normalized;
+                mb.AddPit(centre, outward, 0.060f, 0.035f, 5);
+            }
+        }
+
+        // ── Plant eaters ─────────────────────────────────────────────────────
+
+        // Sparisoma cretense: a deep, laterally compressed body — tall and thin, not a
+        // tube — with a blunt head, a long low dorsal fin and a shallow forked tail.
+        static void BuildParrotfish(MeshBuilder mb)
+        {
+            // profile: z along the body, x = half-width, y = half-height
+            var profile = new (float z, float w, float h, float yOff)[]
+            {
+                (-0.50f, 0.010f, 0.045f,  0.00f), // caudal peduncle
+                (-0.34f, 0.045f, 0.130f,  0.00f),
+                (-0.16f, 0.075f, 0.205f,  0.01f),
+                ( 0.02f, 0.082f, 0.225f,  0.01f), // deepest point
+                ( 0.20f, 0.070f, 0.195f,  0.00f),
+                ( 0.36f, 0.048f, 0.140f, -0.01f),
+                ( 0.47f, 0.026f, 0.080f, -0.02f), // blunt snout
+            };
+            mb.AddBody(profile, 8);
+
+            // Forked caudal fin.
+            mb.AddFinDoubleSided(new Vector3(0f, 0f, -0.50f),
+                                 new Vector3(0f,  0.155f, -0.70f),
+                                 new Vector3(0f,  0.030f, -0.60f));
+            mb.AddFinDoubleSided(new Vector3(0f, 0f, -0.50f),
+                                 new Vector3(0f, -0.155f, -0.70f),
+                                 new Vector3(0f, -0.030f, -0.60f));
+
+            // Long low dorsal fin along the back, and the anal fin beneath.
+            mb.AddFinDoubleSided(new Vector3(0f, 0.20f,  0.14f),
+                                 new Vector3(0f, 0.20f, -0.30f),
+                                 new Vector3(0f, 0.30f, -0.10f));
+            mb.AddFinDoubleSided(new Vector3(0f, -0.17f, -0.05f),
+                                 new Vector3(0f, -0.17f, -0.30f),
+                                 new Vector3(0f, -0.26f, -0.20f));
+
+            // Pectoral fins, one each side.
+            mb.AddFinDoubleSided(new Vector3( 0.07f, -0.02f, 0.16f),
+                                 new Vector3( 0.20f, -0.09f, 0.02f),
+                                 new Vector3( 0.19f,  0.04f, 0.06f));
+            mb.AddFinDoubleSided(new Vector3(-0.07f, -0.02f, 0.16f),
+                                 new Vector3(-0.20f, -0.09f, 0.02f),
+                                 new Vector3(-0.19f,  0.04f, 0.06f));
+        }
+
+        // Diadema africanum: a small dark test carrying very long, fine, mobile
+        // spines. The spines are most of the animal, and most of the silhouette.
+        static void BuildUrchin(MeshBuilder mb, System.Random rng)
+        {
+            const float testRadius = 0.17f;
+            mb.AddEllipsoid(Vector3.zero, new Vector3(testRadius, testRadius * 0.72f, testRadius), 6, 10);
+
+            int spines = 46;
+            for (int i = 0; i < spines; i++)
+            {
+                // Even-ish distribution over the sphere (Fibonacci), jittered.
+                float t = (i + 0.5f) / spines;
+                float phi = Mathf.Acos(1f - 2f * t);
+                float theta = Mathf.PI * (1f + Mathf.Sqrt(5f)) * i;
+
+                var dir = new Vector3(Mathf.Sin(phi) * Mathf.Cos(theta),
+                                      Mathf.Cos(phi) * 0.85f,
+                                      Mathf.Sin(phi) * Mathf.Sin(theta)).normalized;
+
+                // Spines point up and outward; the ones underneath stay short.
+                float length = 0.34f + (float)rng.NextDouble() * 0.30f;
+                if (dir.y < -0.25f) length *= 0.4f;
+
+                Vector3 root = dir * testRadius * 0.92f;
+                mb.AddTaperedSpike(root, root + dir * length, 0.011f, 3);
+            }
+        }
+
+        // Fissurella: a low conical shell with a small opening at the apex. The
+        // keyhole is the diagnostic feature and the reason for the common name, so
+        // the mesh has an actual hole rather than a painted dot.
+        static void BuildLimpet(MeshBuilder mb)
+        {
+            const int segs = 14;
+            const float baseRadius = 0.5f, apexRadius = 0.085f, height = 0.34f;
+
+            // Outer shell wall, from the base rim up to the rim of the keyhole.
+            for (int c = 0; c < segs; c++)
+            {
+                float a0 = c / (float)segs * Mathf.PI * 2f;
+                float a1 = (c + 1) / (float)segs * Mathf.PI * 2f;
+
+                // The shell is a slightly oval cone, as a real limpet is.
+                Vector3 b0 = new Vector3(Mathf.Cos(a0) * baseRadius, 0f, Mathf.Sin(a0) * baseRadius * 0.82f);
+                Vector3 b1 = new Vector3(Mathf.Cos(a1) * baseRadius, 0f, Mathf.Sin(a1) * baseRadius * 0.82f);
+                Vector3 t0 = new Vector3(Mathf.Cos(a0) * apexRadius, height, Mathf.Sin(a0) * apexRadius * 0.82f);
+                Vector3 t1 = new Vector3(Mathf.Cos(a1) * apexRadius, height, Mathf.Sin(a1) * apexRadius * 0.82f);
+
+                // Concave profile — the sides of a limpet curve, they are not straight.
+                Vector3 m0 = Vector3.Lerp(b0, t0, 0.5f); m0.y -= height * 0.10f;
+                Vector3 m1 = Vector3.Lerp(b1, t1, 0.5f); m1.y -= height * 0.10f;
+
+                // Wound so the shell's outside faces outward. Built the other way
+                // round, the limpet renders as the inside of its own shell.
+                mb.AddQuad(b0, m0, m1, b1);
+                mb.AddQuad(m0, t0, t1, m1);
+
+                // Inner wall of the keyhole, which correctly faces inward — it is the
+                // inside of the opening.
+                Vector3 i0 = t0 * 0.72f; i0.y = height * 0.86f;
+                Vector3 i1 = t1 * 0.72f; i1.y = height * 0.86f;
+                mb.AddQuad(t0, i0, i1, t1);
+            }
+        }
+
+        // Panulirus echinatus: segmented armoured body, a fanned tail, and very long
+        // antennae. Deliberately no claws — that absence is the point of its card.
+        static void BuildLobster(MeshBuilder mb)
+        {
+            // Cephalothorax then the articulated abdomen, tapering to the tail.
+            var profile = new (float z, float w, float h, float yOff)[]
+            {
+                (-0.42f, 0.055f, 0.045f, 0.00f),
+                (-0.28f, 0.080f, 0.065f, 0.00f),
+                (-0.12f, 0.100f, 0.085f, 0.00f),
+                ( 0.06f, 0.115f, 0.100f, 0.00f),
+                ( 0.24f, 0.110f, 0.098f, 0.00f),
+                ( 0.38f, 0.085f, 0.075f, 0.00f),
+                ( 0.46f, 0.050f, 0.048f, 0.00f),
+            };
+            mb.AddBody(profile, 7);
+
+            // Tail fan.
+            mb.AddFinDoubleSided(new Vector3(0f, 0f, -0.42f),
+                                 new Vector3( 0.13f, 0.01f, -0.58f),
+                                 new Vector3( 0.02f, 0.01f, -0.60f));
+            mb.AddFinDoubleSided(new Vector3(0f, 0f, -0.42f),
+                                 new Vector3(-0.13f, 0.01f, -0.58f),
+                                 new Vector3(-0.02f, 0.01f, -0.60f));
+
+            // The long antennae, as long as the body — the animal's main defence.
+            mb.AddTaperedSpike(new Vector3( 0.05f, 0.05f, 0.44f),
+                               new Vector3( 0.26f, 0.14f, 1.05f), 0.012f, 4);
+            mb.AddTaperedSpike(new Vector3(-0.05f, 0.05f, 0.44f),
+                               new Vector3(-0.26f, 0.14f, 1.05f), 0.012f, 4);
+
+            // Walking legs — no claws on any of them.
+            for (int i = 0; i < 4; i++)
+            {
+                float z = 0.30f - i * 0.16f;
+                mb.AddTaperedSpike(new Vector3( 0.09f, -0.02f, z),
+                                   new Vector3( 0.26f, -0.14f, z - 0.04f), 0.010f, 3);
+                mb.AddTaperedSpike(new Vector3(-0.09f, -0.02f, z),
+                                   new Vector3(-0.26f, -0.14f, z - 0.04f), 0.010f, 3);
+            }
+        }
+
+        // ── Hunters ──────────────────────────────────────────────────────────
+
+        // Octopus vulgaris: a bulbous mantle over a head, with eight arms tapering
+        // away from it. The arms are built individually and curl outward, which is
+        // what makes the animal read as an octopus at a glance.
+        static void BuildOctopus(MeshBuilder mb, System.Random rng)
+        {
+            // Mantle: the big sac. Sits above and behind the eyes.
+            mb.AddEllipsoid(new Vector3(0f, 0.20f, -0.06f), new Vector3(0.20f, 0.26f, 0.22f), 5, 8);
+            // Head, slightly narrower, carrying the eyes.
+            mb.AddEllipsoid(new Vector3(0f, 0.02f, 0.06f), new Vector3(0.17f, 0.14f, 0.16f), 4, 7);
+            // Eyes, as small domes — they read even at AR distance.
+            mb.AddEllipsoid(new Vector3( 0.13f, 0.06f, 0.10f), new Vector3(0.055f, 0.050f, 0.050f), 3, 5);
+            mb.AddEllipsoid(new Vector3(-0.13f, 0.06f, 0.10f), new Vector3(0.055f, 0.050f, 0.050f), 3, 5);
+
+            const int arms = 8;
+            for (int i = 0; i < arms; i++)
+            {
+                float a = i / (float)arms * Mathf.PI * 2f + 0.2f;
+                Vector3 outward = new Vector3(Mathf.Cos(a), 0f, Mathf.Sin(a));
+                Vector3 pos = new Vector3(0f, -0.05f, 0.02f) + outward * 0.11f;
+
+                // Each arm is a chain of shrinking segments that curls outward and
+                // down, so no two arms sit in the same pose.
+                Vector3 dir = (outward * 0.75f + Vector3.down * 0.35f).normalized;
+                float radius = 0.045f;
+                float segLength = 0.10f + (float)rng.NextDouble() * 0.02f;
+
+                for (int s = 0; s < 4; s++)
+                {
+                    Vector3 next = pos + dir * segLength;
+                    mb.AddTube(pos, next, radius, radius * 0.70f, 4);
+                    pos = next;
+                    radius *= 0.72f;
+                    // Curl: bend further outward and upward toward the tip.
+                    dir = (dir + outward * 0.16f + Vector3.up * (s > 2 ? 0.22f : -0.05f)).normalized;
+                }
+            }
+        }
+
+        // Galeocerdo cuvier: fusiform body, famously blunt snout, tall first dorsal,
+        // and a heterocercal tail whose upper lobe is much the longer. The asymmetric
+        // tail is the giveaway that this is a shark and not a fish.
+        static void BuildTigerShark(MeshBuilder mb)
+        {
+            var profile = new (float z, float w, float h, float yOff)[]
+            {
+                (-0.52f, 0.020f, 0.035f, 0.00f), // caudal peduncle
+                (-0.34f, 0.052f, 0.070f, 0.00f),
+                (-0.14f, 0.085f, 0.105f, 0.00f),
+                ( 0.06f, 0.098f, 0.120f, 0.00f), // thickest just behind the head
+                ( 0.24f, 0.086f, 0.104f, 0.00f),
+                ( 0.40f, 0.058f, 0.072f, 0.00f),
+                ( 0.50f, 0.030f, 0.042f, -0.01f), // blunt, squared-off snout
+            };
+            mb.AddBody(profile, 8);
+
+            // Heterocercal caudal fin: long upper lobe, short lower one.
+            mb.AddFinDoubleSided(new Vector3(0f, 0.01f, -0.52f),
+                                 new Vector3(0f, 0.30f, -0.86f),
+                                 new Vector3(0f, 0.05f, -0.66f));
+            mb.AddFinDoubleSided(new Vector3(0f, -0.01f, -0.52f),
+                                 new Vector3(0f, -0.13f, -0.74f),
+                                 new Vector3(0f, -0.03f, -0.62f));
+
+            // Tall first dorsal fin, well forward.
+            mb.AddFinDoubleSided(new Vector3(0f, 0.11f,  0.14f),
+                                 new Vector3(0f, 0.11f, -0.04f),
+                                 new Vector3(0f, 0.34f,  0.02f));
+            // Small second dorsal, far back.
+            mb.AddFinDoubleSided(new Vector3(0f, 0.06f, -0.30f),
+                                 new Vector3(0f, 0.06f, -0.42f),
+                                 new Vector3(0f, 0.14f, -0.36f));
+
+            // Long pectoral fins, swept back.
+            mb.AddFinDoubleSided(new Vector3( 0.08f, -0.04f,  0.16f),
+                                 new Vector3( 0.34f, -0.14f, -0.06f),
+                                 new Vector3( 0.12f, -0.05f, -0.02f));
+            mb.AddFinDoubleSided(new Vector3(-0.08f, -0.04f,  0.16f),
+                                 new Vector3(-0.34f, -0.14f, -0.06f),
+                                 new Vector3(-0.12f, -0.05f, -0.02f));
+        }
+    }
+
+    // Accumulates geometry, then bakes one mesh. Kept deliberately small — just the
+    // primitives the roster above actually needs.
+    class MeshBuilder
+    {
+        readonly List<Vector3> _verts = new List<Vector3>(512);
+        readonly List<int> _tris = new List<int>(1024);
+
+        int Add(Vector3 v) { _verts.Add(v); return _verts.Count - 1; }
+
+        public void AddTri(Vector3 a, Vector3 b, Vector3 c)
+        {
+            int i = Add(a); Add(b); Add(c);
+            _tris.Add(i); _tris.Add(i + 1); _tris.Add(i + 2);
+        }
+
+        public void AddQuad(Vector3 a, Vector3 b, Vector3 c, Vector3 d)
+        {
+            AddTri(a, b, c);
+            AddTri(a, c, d);
+        }
+
+        // Fins and algal blades are flat sheets; without both faces they vanish when
+        // seen from the wrong side.
+        public void AddQuadDoubleSided(Vector3 a, Vector3 b, Vector3 c, Vector3 d)
+        {
+            AddQuad(a, b, c, d);
+            AddQuad(d, c, b, a);
+        }
+
+        // Fins get thickness for the same reason the algal blade does: a flat
+        // double-sided triangle has one black side whichever way the light falls.
+        public void AddFinDoubleSided(Vector3 a, Vector3 b, Vector3 c)
+        {
+            Vector3 n = Vector3.Cross(b - a, c - a);
+            if (n.sqrMagnitude < 1e-12f) return;
+
+            float thickness = Mathf.Sqrt(n.magnitude) * 0.05f;
+            Vector3 offset = n.normalized * thickness * 0.5f;
+
+            Vector3 a0 = a + offset, b0 = b + offset, c0 = c + offset;
+            Vector3 a1 = a - offset, b1 = b - offset, c1 = c - offset;
+
+            AddTri(a0, b0, c0);
+            AddTri(c1, b1, a1);
+            AddQuad(a0, c0, c1, a1);
+            AddQuad(c0, b0, b1, c1);
+            AddQuad(b0, a0, a1, b1);
+        }
+
+        // A curved surface given thickness: front, back and a rim all the way round.
+        public void AddSheet(Vector3[,] grid, int rings, int cols, float thickness)
+        {
+            float half = Mathf.Max(0.0005f, thickness) * 0.5f;
+            var normals = new Vector3[rings + 1, cols + 1];
+
+            for (int r = 0; r <= rings; r++)
+                for (int c = 0; c <= cols; c++)
+                {
+                    Vector3 du = grid[Mathf.Min(r + 1, rings), c] - grid[Mathf.Max(r - 1, 0), c];
+                    Vector3 dv = grid[r, Mathf.Min(c + 1, cols)] - grid[r, Mathf.Max(c - 1, 0)];
+                    Vector3 n = Vector3.Cross(du, dv);
+                    normals[r, c] = n.sqrMagnitude > 1e-12f ? n.normalized : Vector3.up;
+                }
+
+            Vector3 Front(int r, int c) => grid[r, c] + normals[r, c] * half;
+            Vector3 Back(int r, int c) => grid[r, c] - normals[r, c] * half;
+
+            // Wound so every face points out of the solid. Verified by the
+            // signed-volume check in the balance report rather than by deriving cross
+            // products on paper, which is how the blade ended up inside-out twice.
+            for (int r = 0; r < rings; r++)
+                for (int c = 0; c < cols; c++)
+                {
+                    AddQuad(Front(r, c), Front(r, c + 1), Front(r + 1, c + 1), Front(r + 1, c));
+                    AddQuad(Back(r, c), Back(r + 1, c), Back(r + 1, c + 1), Back(r, c + 1));
+                }
+
+            // Rim around all four edges, so the blade reads as solid at grazing angles.
+            for (int c = 0; c < cols; c++)
+            {
+                AddQuad(Front(0, c + 1), Back(0, c + 1), Back(0, c), Front(0, c));
+                AddQuad(Front(rings, c), Back(rings, c), Back(rings, c + 1), Front(rings, c + 1));
+            }
+            for (int r = 0; r < rings; r++)
+            {
+                AddQuad(Front(r, 0), Back(r, 0), Back(r + 1, 0), Front(r + 1, 0));
+                AddQuad(Front(r + 1, cols), Back(r + 1, cols), Back(r, cols), Front(r, cols));
+            }
+        }
+
+        // A closed body swept along z through a list of oval cross-sections, capped
+        // at both ends. This is what makes a fish read as a fish.
+        public void AddBody((float z, float w, float h, float yOff)[] profile, int sides)
+        {
+            var rings = new Vector3[profile.Length][];
+            for (int p = 0; p < profile.Length; p++)
+            {
+                rings[p] = new Vector3[sides];
+                for (int s = 0; s < sides; s++)
+                {
+                    float a = s / (float)sides * Mathf.PI * 2f;
+                    rings[p][s] = new Vector3(Mathf.Cos(a) * profile[p].w,
+                                              Mathf.Sin(a) * profile[p].h + profile[p].yOff,
+                                              profile[p].z);
+                }
+            }
+
+            for (int p = 0; p < profile.Length - 1; p++)
+                for (int s = 0; s < sides; s++)
+                {
+                    int n = (s + 1) % sides;
+                    AddQuad(rings[p][s], rings[p][n], rings[p + 1][n], rings[p + 1][s]);
+                }
+
+            // Caps.
+            var tail = new Vector3(0f, profile[0].yOff, profile[0].z);
+            var nose = new Vector3(0f, profile[^1].yOff, profile[^1].z);
+            for (int s = 0; s < sides; s++)
+            {
+                int n = (s + 1) % sides;
+                AddTri(tail, rings[0][n], rings[0][s]);
+                AddTri(nose, rings[^1][s], rings[^1][n]);
+            }
+        }
+
+        public void AddEllipsoid(Vector3 centre, Vector3 radii, int rings, int segs)
+        {
+            var grid = new Vector3[rings + 1, segs + 1];
+            for (int r = 0; r <= rings; r++)
+            {
+                float phi = r / (float)rings * Mathf.PI;
+                for (int c = 0; c <= segs; c++)
+                {
+                    float theta = c / (float)segs * Mathf.PI * 2f;
+                    grid[r, c] = centre + new Vector3(
+                        Mathf.Sin(phi) * Mathf.Cos(theta) * radii.x,
+                        Mathf.Cos(phi) * radii.y,
+                        Mathf.Sin(phi) * Mathf.Sin(theta) * radii.z);
+                }
+            }
+            // Wound the same way round as the coral dome below. The other order puts
+            // every normal on the inside, which turns the octopus mantle and the
+            // urchin's test inside-out — you end up looking at the far wall of the
+            // model through its near one.
+            for (int r = 0; r < rings; r++)
+                for (int c = 0; c < segs; c++)
+                    AddQuad(grid[r, c], grid[r, c + 1], grid[r + 1, c + 1], grid[r + 1, c]);
+        }
+
+        public void AddTube(Vector3 from, Vector3 to, float r0, float r1, int sides)
+        {
+            Vector3 axis = (to - from).normalized;
+            Vector3 up = Mathf.Abs(axis.y) > 0.9f ? Vector3.right : Vector3.up;
+            Vector3 x = Vector3.Cross(axis, up).normalized;
+            Vector3 y = Vector3.Cross(axis, x);
+
+            for (int s = 0; s < sides; s++)
+            {
+                float a0 = s / (float)sides * Mathf.PI * 2f;
+                float a1 = (s + 1) / (float)sides * Mathf.PI * 2f;
+                Vector3 d0 = x * Mathf.Cos(a0) + y * Mathf.Sin(a0);
+                Vector3 d1 = x * Mathf.Cos(a1) + y * Mathf.Sin(a1);
+                AddQuad(from + d0 * r0, from + d1 * r0, to + d1 * r1, to + d0 * r1);
+            }
+        }
+
+        // A spine, antenna or leg: a tube that closes to a point.
+        public void AddTaperedSpike(Vector3 from, Vector3 to, float radius, int sides)
+        {
+            Vector3 axis = (to - from).normalized;
+            Vector3 up = Mathf.Abs(axis.y) > 0.9f ? Vector3.right : Vector3.up;
+            Vector3 x = Vector3.Cross(axis, up).normalized;
+            Vector3 y = Vector3.Cross(axis, x);
+
+            for (int s = 0; s < sides; s++)
+            {
+                float a0 = s / (float)sides * Mathf.PI * 2f;
+                float a1 = (s + 1) / (float)sides * Mathf.PI * 2f;
+                Vector3 d0 = x * Mathf.Cos(a0) + y * Mathf.Sin(a0);
+                Vector3 d1 = x * Mathf.Cos(a1) + y * Mathf.Sin(a1);
+                AddTri(from + d0 * radius, from + d1 * radius, to);
+                AddTri(from, from + d1 * radius, from + d0 * radius);
+            }
+        }
+
+        // A flat segment, as in a Halimeda chain: a thin disc with a rim.
+        public void AddDisc(Vector3 centre, Vector3 axis, Vector3 normal,
+                            float radiusA, float radiusB, int sides, float thickness)
+        {
+            Vector3 n = normal.normalized;
+            Vector3 u = Vector3.Cross(n, axis).normalized;
+            Vector3 v = Vector3.Cross(n, u);
+
+            Vector3 front = centre + n * thickness * 0.5f;
+            Vector3 back = centre - n * thickness * 0.5f;
+
+            for (int s = 0; s < sides; s++)
+            {
+                float a0 = s / (float)sides * Mathf.PI * 2f;
+                float a1 = (s + 1) / (float)sides * Mathf.PI * 2f;
+                Vector3 p0 = u * Mathf.Cos(a0) * radiusA + v * Mathf.Sin(a0) * radiusB;
+                Vector3 p1 = u * Mathf.Cos(a1) * radiusA + v * Mathf.Sin(a1) * radiusB;
+
+                AddTri(front, front + p0, front + p1);
+                AddTri(back, back + p1, back + p0);
+                AddQuad(front + p0, back + p0, back + p1, front + p1);
+            }
+        }
+
+        // A corallite: a small cup sunk into a surface.
+        public void AddPit(Vector3 centre, Vector3 outward, float radius, float depth, int sides)
+        {
+            Vector3 n = outward.normalized;
+            Vector3 up = Mathf.Abs(n.y) > 0.9f ? Vector3.right : Vector3.up;
+            Vector3 x = Vector3.Cross(n, up).normalized;
+            Vector3 y = Vector3.Cross(n, x);
+            Vector3 floor = centre - n * depth;
+
+            for (int s = 0; s < sides; s++)
+            {
+                float a0 = s / (float)sides * Mathf.PI * 2f;
+                float a1 = (s + 1) / (float)sides * Mathf.PI * 2f;
+                Vector3 r0 = x * Mathf.Cos(a0) * radius + y * Mathf.Sin(a0) * radius;
+                Vector3 r1 = x * Mathf.Cos(a1) * radius + y * Mathf.Sin(a1) * radius;
+                AddQuad(centre + r0, centre + r1, floor + r1 * 0.45f, floor + r0 * 0.45f);
+                AddTri(floor, floor + r0 * 0.45f, floor + r1 * 0.45f);
+            }
+        }
+
+        public Mesh ToMesh(string name)
+        {
+            var mesh = new Mesh { name = name };
+            if (_verts.Count > 65000) mesh.indexFormat = UnityEngine.Rendering.IndexFormat.UInt32;
+            mesh.SetVertices(_verts);
+            mesh.SetTriangles(_tris, 0);
+            mesh.SetNormals(BuildNormals(55f));
+            mesh.RecalculateBounds();
+            mesh.UploadMeshData(true);   // no CPU copy kept; these are never re-read
+            return mesh;
+        }
+
+        // Smooths across gentle curvature while keeping genuine edges sharp.
+        //
+        // Every vertex here is unshared, so plain RecalculateNormals gives a purely
+        // faceted result and a curved body — an octopus mantle, a fish flank, an
+        // urchin's test — reads as a lump of rock. Averaging normals between
+        // coincident vertices only where their faces agree to within the smoothing
+        // angle rounds those surfaces off, while a fin's two opposed faces (180°
+        // apart) and a hard crease stay crisp.
+        List<Vector3> BuildNormals(float smoothingAngleDegrees)
+        {
+            int n = _verts.Count;
+            var faceNormals = new Vector3[n];
+
+            for (int t = 0; t < _tris.Count; t += 3)
+            {
+                int i0 = _tris[t], i1 = _tris[t + 1], i2 = _tris[t + 2];
+                Vector3 normal = Vector3.Cross(_verts[i1] - _verts[i0], _verts[i2] - _verts[i0]);
+                faceNormals[i0] = normal;
+                faceNormals[i1] = normal;
+                faceNormals[i2] = normal;
+            }
+
+            // Bucket coincident vertices. 0.1 mm is far below anything these shapes
+            // resolve, so this only ever merges vertices that are genuinely the same.
+            var buckets = new Dictionary<long, List<int>>(n);
+            for (int i = 0; i < n; i++)
+            {
+                var v = _verts[i];
+                long key = ((long)Mathf.Round(v.x * 10000f) * 73856093)
+                         ^ ((long)Mathf.Round(v.y * 10000f) * 19349663)
+                         ^ ((long)Mathf.Round(v.z * 10000f) * 83492791);
+                if (!buckets.TryGetValue(key, out var list))
+                    buckets[key] = list = new List<int>(4);
+                list.Add(i);
+            }
+
+            float cosLimit = Mathf.Cos(smoothingAngleDegrees * Mathf.Deg2Rad);
+            var normals = new List<Vector3>(n);
+            for (int i = 0; i < n; i++) normals.Add(Vector3.zero);
+
+            foreach (var bucket in buckets.Values)
+            {
+                for (int a = 0; a < bucket.Count; a++)
+                {
+                    int ia = bucket[a];
+                    Vector3 own = faceNormals[ia].normalized;
+                    Vector3 sum = Vector3.zero;
+
+                    for (int b = 0; b < bucket.Count; b++)
+                    {
+                        int ib = bucket[b];
+                        // Weighted by face area (the un-normalised cross product),
+                        // which is what stops small slivers skewing a smooth surface.
+                        if (Vector3.Dot(own, faceNormals[ib].normalized) >= cosLimit)
+                            sum += faceNormals[ib];
+                    }
+
+                    normals[ia] = sum.sqrMagnitude > 1e-12f ? sum.normalized : own;
+                }
+            }
+
+            return normals;
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/View/ReefMeshLibrary.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/View/ReefMeshLibrary.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 681ffd1c79bd3a04093dceca1168efb9

--- a/Assets/Scripts/LivingEcosystem/View/SpeciesVisualLibrary.cs
+++ b/Assets/Scripts/LivingEcosystem/View/SpeciesVisualLibrary.cs
@@ -1,0 +1,119 @@
+using UnityEngine;
+
+namespace CreateEnv.Ecosystem
+{
+    // Where a species' model and material come from.
+    //
+    //   1. A prefab at Resources/LivingEcosystem/Species/<id>, if one exists.
+    //   2. Otherwise a species-shaped mesh from ReefMeshLibrary.
+    //
+    // Meshes AND materials are built once per species and shared by every instance.
+    // That sharing is not tidiness, it is the frame rate: giving each drawn organism
+    // its own Material meant fifty-odd unique materials, fifty draw calls and no
+    // batching whatsoever. Anything that varies per individual — an octopus's
+    // camouflage, a highlight — goes through a MaterialPropertyBlock instead, which
+    // leaves the batching intact.
+    public static class SpeciesVisualLibrary
+    {
+        const string PrefabPath = "LivingEcosystem/Species/";
+
+        static readonly GameObject[] _prefabs = new GameObject[SpeciesLibrary.Count];
+        static readonly Mesh[] _meshes = new Mesh[SpeciesLibrary.Count];
+        static readonly Material[] _materials = new Material[SpeciesLibrary.Count];
+        static readonly bool[] _resolved = new bool[SpeciesLibrary.Count];
+        static Material _template;
+
+        // Shader property ids, looked up once. Resolving them by string on every
+        // assignment is a surprising amount of work when it happens per organism.
+        public static readonly int BaseColorId = Shader.PropertyToID("_BaseColor");
+        public static readonly int ColorId = Shader.PropertyToID("_Color");
+        public static readonly int EmissionId = Shader.PropertyToID("_EmissionColor");
+
+        public static GameObject PrefabFor(int species)
+        {
+            Resolve(species);
+            return _prefabs[species];
+        }
+
+        public static Mesh MeshFor(int species)
+        {
+            Resolve(species);
+            return _meshes[species];
+        }
+
+        // One material per species, shared by every one of its instances.
+        public static Material MaterialFor(int species)
+        {
+            if (species < 0 || species >= _materials.Length) return Template;
+            if (_materials[species] != null) return _materials[species];
+
+            var def = SpeciesLibrary.Get(species);
+            var mat = new Material(Template) { name = "LivingEcosystem/" + (def != null ? def.id : species.ToString()) };
+            if (def != null)
+            {
+                if (mat.HasProperty(BaseColorId)) mat.SetColor(BaseColorId, def.tint);
+                if (mat.HasProperty(ColorId)) mat.SetColor(ColorId, def.tint);
+            }
+            _materials[species] = mat;
+            return mat;
+        }
+
+        public static void Invalidate()
+        {
+            for (int i = 0; i < _resolved.Length; i++)
+            {
+                _resolved[i] = false;
+                _prefabs[i] = null;
+                _meshes[i] = null;
+                _materials[i] = null;
+            }
+        }
+
+        static void Resolve(int species)
+        {
+            if (species < 0 || species >= SpeciesLibrary.Count) return;
+            if (_resolved[species]) return;
+            _resolved[species] = true;
+
+            var def = SpeciesLibrary.Get(species);
+            if (def == null) return;
+
+            var prefab = Resources.Load<GameObject>(PrefabPath + def.id);
+            if (prefab != null)
+            {
+                _prefabs[species] = prefab;
+                return;
+            }
+
+            // Seeded per species so each looks the same between sessions, and built
+            // to that species' own diagnostic silhouette.
+            _meshes[species] = ReefMeshLibrary.Build(species, 4100 + species * 37);
+        }
+
+        // Simple Lit rather than Unlit: these meshes carry their meaning in their
+        // shape, and an unlit shader flattens every one of them into a solid
+        // silhouette where a limpet and an urchin look identical.
+        public static Material Template
+        {
+            get
+            {
+                if (_template != null) return _template;
+
+                var shader = Shader.Find("Universal Render Pipeline/Simple Lit")
+                          ?? Shader.Find("Universal Render Pipeline/Lit")
+                          ?? Shader.Find("Universal Render Pipeline/Unlit")
+                          ?? Shader.Find("Diffuse");
+
+                _template = new Material(shader) { enableInstancing = true };
+                _template.name = "LivingEcosystem/Template";
+
+                // Rough, non-metallic, no specular highlight: wet organic surfaces.
+                if (_template.HasProperty("_Smoothness")) _template.SetFloat("_Smoothness", 0.12f);
+                if (_template.HasProperty("_Metallic")) _template.SetFloat("_Metallic", 0f);
+                if (_template.HasProperty("_SpecularHighlights")) _template.SetFloat("_SpecularHighlights", 0f);
+
+                return _template;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/LivingEcosystem/View/SpeciesVisualLibrary.cs.meta
+++ b/Assets/Scripts/LivingEcosystem/View/SpeciesVisualLibrary.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e5de02a2e4e45d0498d0ebe2856276a7


### PR DESCRIPTION
Adds a simulated Cabo Verde reef with individual octopuses, inheritance, and a shareable report. Installs itself at runtime, so no Addressable scene data is edited. FreeExplore is untouched.

Milestone 1 - The Living Reef
- 9-species food web with Holling type II feeding, prey refuge, logistic growth, recruitment and a detritus loop
- Health stages, rewind buffer, and a Why panel that explains each state in plain language
- Procedural meshes and depth/motion behaviour per species
- Energy pyramid, organism picker, barren prompt

Milestone 2 - The Octopus
- Mendelian genetics: camouflage, body size, heat tolerance
- Individual agents with age, energy, brooding, semelparity and planktonic settlement
- Inspector, breeding tool with Punnett prediction, family tree

Milestone 3 - Memory and Meaning
- Rolling quantised history and a ranked event journal
- Save/resume per environment, under a 4 KB budget
- "While you were away": 1 real hour = 1 reef day, capped at 14
- Two-page PDF report written in C# (no plugin), shared to Downloads via MediaStore - no AndroidManifest change needed
- In-app toast reporting where the file was saved

Config and tooling
- Ecosystem section in CustomEnvBuilder, carried on EnvironmentProfile
- Editor windows: balance tuning, reef preview, saved reefs and sample-report generation

Performance
- One shared material per species plus MaterialPropertyBlock for per-octopus tint (was one material per drawn instance)
- Throttled seabed raycast and WaterSurface lookup; UI refresh gated while the panel is closed

Existing files touched: 18 added lines, none changed or deleted (EnvironmentProfile, EnvironmentBounds, EnvironmentEditorUI).